### PR TITLE
chore: sync infrastructure from bun-typescript-starter template

### DIFF
--- a/.github/workflows/alpha-snapshot.yml
+++ b/.github/workflows/alpha-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/autogenerate-changeset.yml
+++ b/.github/workflows/autogenerate-changeset.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
@@ -28,13 +28,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           languages: javascript-typescript
           # JS/TS analysis doesn't require a build; avoid flaky autobuild on pnpm projects
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
         with:
           category: '/language:javascript'

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,7 +19,7 @@ jobs:
           github.actor != 'renovate[bot]' }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,17 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Require dev-dependencies label
+      - name: Require auto-mergeable label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: labels
         with:
           script: |
             const labels = (context.payload.pull_request.labels || []).map(l => l.name)
-            const hasDevLabel = labels.includes('dev-dependencies')
-            if (!hasDevLabel) {
-              core.setFailed('PR is not labeled dev-dependencies; skipping auto-merge')
+            const allowed = ['dev-dependencies', 'github_actions']
+            const hasAllowed = labels.some(l => allowed.includes(l))
+            if (!hasAllowed) {
+              core.setFailed(`PR labels [${labels.join(', ')}] do not include any of: ${allowed.join(', ')}`)
             }
-      - name: Check changed files for devDependencies only
+      - name: Check changed files are safe to auto-merge
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: diff
         with:
@@ -41,11 +42,12 @@ jobs:
               'yarn.lock',
               'bun.lock',
             ]
-            const onlyAllowed = filenames.every(f => allowed.includes(f))
-            if (!onlyAllowed) {
-              core.setFailed('PR touches files outside dependency manifests')
+            const isGHA = filenames.every(f => f.startsWith('.github/'))
+            const isDeps = filenames.every(f => allowed.includes(f))
+            if (!isGHA && !isDeps) {
+              core.setFailed('PR touches files outside dependency manifests and .github/')
             }
-      - name: Enable auto-merge for minor/patch dev dependency updates
+      - name: Enable auto-merge for minor/patch dependency updates
         if: steps.diff.outcome == 'success' && steps.labels.outcome == 'success'
         uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/node-compat.yml
+++ b/.github/workflows/node-compat.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/package-hygiene.yml
+++ b/.github/workflows/package-hygiene.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
@@ -203,10 +203,23 @@ jobs:
     name: All checks passed
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test, quality, lint-scripts]
+    if: always()
     timeout-minutes: 5
     steps:
-      - name: Aggregate result
-        run: echo "All prerequisite PR quality jobs succeeded." && exit 0
+      - name: Check all jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            echo
+            echo "Results:"
+            echo "  Lint: ${{ needs.lint.result }}"
+            echo "  Typecheck: ${{ needs.typecheck.result }}"
+            echo "  Tests + Coverage: ${{ needs.test.result }}"
+            echo "  Repo quality: ${{ needs.quality.result }}"
+            echo "  Lint Shell Scripts: ${{ needs.lint-scripts.result }}"
+            exit 1
+          fi
+          echo "All prerequisite PR quality jobs succeeded."
       - name: PR summary
         if: always()
         shell: bash

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/pre-mode.yml
+++ b/.github/workflows/pre-mode.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
       # ============================================================
 
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
@@ -126,6 +126,21 @@ jobs:
           fi
 
       # ============================================================
+      # GitHub App Token (bypasses anti-recursion)
+      # ============================================================
+      # GITHUB_TOKEN commits don't trigger workflows (GitHub anti-recursion).
+      # The changesets action pushes to changeset-release/main which must
+      # trigger version-packages-auto-merge.yml. Using a GitHub App token
+      # ensures those pushes fire pull_request_target events.
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # ============================================================
       # Intent Computation
       # ============================================================
 
@@ -165,7 +180,7 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
 
@@ -192,7 +207,7 @@ jobs:
             echo "Release ${TAG} already exists, skipping release creation"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # ============================================================
       # Build & Git Config (for version/publish/snapshot)
@@ -215,7 +230,7 @@ jobs:
       - name: Version prerelease
         if: steps.intent.outputs.value == 'version'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: '0'
         run: |
           bun run version:pre
@@ -275,13 +290,13 @@ jobs:
         if: steps.intent.outputs.value == 'publish'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bun run publish:pre
 
       - name: Create GitHub Release (Prerelease)
         if: steps.intent.outputs.value == 'publish'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: '0'
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -310,5 +325,5 @@ jobs:
         if: steps.intent.outputs.value == 'snapshot'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bun run release:snapshot:canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,28 +32,19 @@ jobs:
           node-version: '24'  # Node 24 includes npm 11.6+ (required for OIDC trusted publishing)
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb # v3.1.0
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: op://API Credentials/chatline-changesets-bot/App ID
-          GITHUB_APP_PRIVATE_KEY: op://API Credentials/chatline-changesets-bot/credential
-
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - run: bun install --frozen-lockfile
       - name: Code quality (safe fixes)
         run: bun run quality-check:ci
       - run: bun run build
       - name: Generate SBOM (CycloneDX JSON)
-        uses: anchore/sbom-action@deef08a0db64bfad603422135db61477b16cef56 # v0.22.1
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
         with:
           path: .
           format: cyclonedx-json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/tag-assets.yml
+++ b/.github/workflows/tag-assets.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: bun run build
       - name: Generate SBOM
-        uses: anchore/sbom-action@deef08a0db64bfad603422135db61477b16cef56 # v0.22.1
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
         with:
           path: .
           format: cyclonedx-json

--- a/.github/workflows/version-packages-auto-merge.yml
+++ b/.github/workflows/version-packages-auto-merge.yml
@@ -17,25 +17,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
-
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb # v3.1.0
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: op://API Credentials/chatline-changesets-bot/App ID
-          GITHUB_APP_PRIVATE_KEY: op://API Credentials/chatline-changesets-bot/credential
 
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Enable PR auto-merge (squash)
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -49,3 +40,21 @@ jobs:
               }
             `, { prId: pr.node_id })
             core.info('Auto-merge enabled for Version Packages PR')
+
+      # GITHUB_TOKEN PRs don't trigger workflows (GitHub anti-recursion).
+      # Dispatch pr-quality.yml using the App token so the required "All
+      # checks passed" gate job runs and branch protection is satisfied.
+      - name: Trigger PR quality checks on version branch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const branch = context.payload.pull_request.head.ref
+            core.info(`Dispatching PR quality workflow on ${branch}`)
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pr-quality.yml',
+              ref: branch,
+            })
+            core.info('PR quality workflow dispatched')

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ report.*.json
 # Claude Code local memory
 CLAUDE.local.md
 
+# Husky local markers
+.husky/.protection-verified
+
 # Test artifacts
 test-results/
 .vitest/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,3 +11,36 @@ if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
     exit 1
   fi
 fi
+
+# Remind users to enable branch protection (one-time, non-blocking).
+# Once verified, creates a marker file so it never checks again.
+MARKER=".husky/.protection-verified"
+if [ ! -f "$MARKER" ] && command -v gh >/dev/null 2>&1; then
+  repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
+  if [ -n "$repo" ]; then
+    # Capture HTTP status to distinguish "not enabled" (404) from "no permission" (403).
+    http_status=$(gh api "repos/$repo/branches/main/protection" \
+      --silent --include 2>/dev/null \
+      | head -1 | awk '{print $2}') || true
+    case "${http_status:-}" in
+      200)
+        # Protection is enabled -- mark as verified.
+        mkdir -p .husky
+        touch "$MARKER"
+        ;;
+      404)
+        # Protection genuinely not configured.
+        echo ""
+        echo "WARNING: Branch protection is not enabled on main."
+        echo "Run 'bun run setup:protect' to enable it."
+        echo ""
+        ;;
+      403)
+        # User lacks admin access -- can't determine status, skip silently.
+        ;;
+      *)
+        # Network error or unexpected status -- skip silently.
+        ;;
+    esac
+  fi
+fi


### PR DESCRIPTION
## Summary

- Bump action versions: harden-runner v2.14.2, CodeQL v4.32.2, sbom-action v0.22.2
- Migrate `publish.yml` and `version-packages-auto-merge.yml` from 1Password/GITHUB_TOKEN to GitHub App token (`APP_ID` variable + `APP_PRIVATE_KEY` secret)
- Migrate `release.yml` from 1Password to direct GitHub App secrets
- Improve `pr-quality.yml` gate job with explicit failure/cancelled checking and detailed status output
- Add `github_actions` label support to `dependabot-auto-merge.yml` for auto-merging GHA updates
- Add branch protection verification to `.husky/pre-push` hook (one-time non-blocking reminder)
- Add `.husky/.protection-verified` to `.gitignore`

## What changed

| Item | Before | After |
|------|--------|-------|
| harden-runner | v2.14.1 | v2.14.2 (all 17 workflows) |
| CodeQL | v4.32.0 | v4.32.2 |
| sbom-action | v0.22.1 | v0.22.2 |
| publish.yml auth | `GITHUB_TOKEN` | GitHub App token via `vars.APP_ID` / `secrets.APP_PRIVATE_KEY` |
| auto-merge auth | 1Password `OP_SERVICE_ACCOUNT_TOKEN` | Direct `vars.APP_ID` / `secrets.APP_PRIVATE_KEY` |
| release.yml auth | 1Password `OP_SERVICE_ACCOUNT_TOKEN` | Direct `vars.APP_ID` / `secrets.APP_PRIVATE_KEY` |
| pr-quality gate | Simple `echo` + `exit 0` | Explicit failure checking with per-job status |
| dependabot labels | `dev-dependencies` only | `dev-dependencies` + `github_actions` |
| pre-push hook | Branch block only | Branch block + protection verification |

## Repo setup

`APP_ID` variable and `APP_PRIVATE_KEY` secret have been configured on the repo (sourced from 1Password `chatline-changesets-bot`).

## Test plan

- [x] `bun run validate` passes (lint, typecheck, build, 40 tests)
- [ ] Verify `publish.yml` works on next merge to main
- [ ] Verify `version-packages-auto-merge.yml` triggers and auto-merges version PRs
- [ ] Verify dependabot GHA update PRs get auto-merged with `github_actions` label