### PR TITLE
feat: add --outdir flag for custom output directory

### DIFF
--- a/.changeset/add-outdir-flag.md
+++ b/.changeset/add-outdir-flag.md
@@ -1,0 +1,5 @@
+---
+'@side-quest/last-30-days': patch
+---
+
+Add --outdir flag to write output files to a custom directory instead of the default ~/.local/share/last-30-days/out/. This enables parallel CLI invocations to write to isolated directories without racing on the same output path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export {
 } from './lib/openai-reddit.js'
 // Rendering
 export {
+	getContextPath,
 	renderCompact,
 	renderContextSnippet,
 	renderFullReport,


### PR DESCRIPTION
## Summary

- Adds `--outdir=PATH` CLI flag so parallel invocations can write to isolated directories instead of racing on `~/.local/share/last-30-days/out/`
- Exports `getContextPath()` from library API for programmatic use
- Includes 7 new tests (5 CLI integration + 2 unit)

## Test plan

- [x] `bun run validate` passes (lint, types, build, 117 tests)
- [ ] Manual: `bun run dist/cli.js "test" --mock --outdir=/tmp/l30d-test/` writes files to specified dir
- [ ] Manual: `bun run dist/cli.js "test" --mock --emit=path --outdir=/tmp/l30d-test/` returns correct path

Closes #23