### PR TITLE
feat(briefing): add briefing and delta intelligence

### DIFF
--- a/fixtures/eval/baseline.json
+++ b/fixtures/eval/baseline.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-02-18T12:38:01.962Z",
+	"generatedAt": "2026-02-20T02:58:55.902Z",
 	"topicCount": 10,
 	"kpis": {
 		"runReliability": 1,
-		"performanceP95Seconds": 0.01980375000000001,
-		"avgCitationValidity": 0,
-		"avgTrendRecallAt10": 0,
-		"avgOracleRecall": 0
+		"performanceP95Seconds": 0.025385165999999997,
+		"avgCitationValidity": 1,
+		"avgTrendRecallAt10": 0.06000000000000001,
+		"avgOracleRecall": 0.1
 	},
 	"thresholds": {
 		"citationValidity": 0.5,
@@ -15,7 +15,7 @@
 		"regressionSafetyThreshold": 0.02
 	},
 	"passed": {
-		"citationValidity": false,
+		"citationValidity": true,
 		"runReliability": true,
 		"performanceP95": true,
 		"regressionSafety": true
@@ -25,101 +25,101 @@
 			"topic": "Claude AI prompting techniques",
 			"category": "prompting",
 			"success": true,
-			"durationSeconds": 0.019628125,
-			"citationValidity": 0,
-			"trendRecallAt10": 0,
-			"oracleRecall": 0,
-			"itemCount": 0
+			"durationSeconds": 0.025385165999999997,
+			"citationValidity": 1,
+			"trendRecallAt10": 0.2,
+			"oracleRecall": 0.4,
+			"itemCount": 9
 		},
 		{
 			"topic": "React Server Components",
 			"category": "trending",
 			"success": true,
-			"durationSeconds": 0.018666542,
-			"citationValidity": 0,
+			"durationSeconds": 0.024394915999999996,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "Rust vs Go 2025",
 			"category": "evergreen",
 			"success": true,
-			"durationSeconds": 0.018273207999999996,
-			"citationValidity": 0,
+			"durationSeconds": 0.024368208000000002,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "OpenAI o3 model",
 			"category": "news",
 			"success": true,
-			"durationSeconds": 0.019608333000000002,
-			"citationValidity": 0,
+			"durationSeconds": 0.023473792000000004,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
-			"oracleRecall": 0,
-			"itemCount": 0
+			"oracleRecall": 0.2,
+			"itemCount": 9
 		},
 		{
 			"topic": "TypeScript 5.8 features",
 			"category": "trending",
 			"success": true,
-			"durationSeconds": 0.018603958000000007,
-			"citationValidity": 0,
+			"durationSeconds": 0.02387120800000001,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "LLM fine-tuning best practices",
 			"category": "recommendations",
 			"success": true,
-			"durationSeconds": 0.01980375000000001,
-			"citationValidity": 0,
-			"trendRecallAt10": 0,
-			"oracleRecall": 0,
-			"itemCount": 0
+			"durationSeconds": 0.023049166000000013,
+			"citationValidity": 1,
+			"trendRecallAt10": 0.2,
+			"oracleRecall": 0.2,
+			"itemCount": 9
 		},
 		{
 			"topic": "Bun runtime performance",
 			"category": "niche",
 			"success": true,
-			"durationSeconds": 0.019143124999999983,
-			"citationValidity": 0,
+			"durationSeconds": 0.022541458000000007,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "AI code review tools",
 			"category": "recommendations",
 			"success": true,
-			"durationSeconds": 0.018803082999999988,
-			"citationValidity": 0,
+			"durationSeconds": 0.022609083999999995,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "WebAssembly WASI preview 2",
 			"category": "niche",
 			"success": true,
-			"durationSeconds": 0.019797125000000023,
-			"citationValidity": 0,
+			"durationSeconds": 0.022063500000000003,
+			"citationValidity": 1,
 			"trendRecallAt10": 0,
 			"oracleRecall": 0,
-			"itemCount": 0
+			"itemCount": 9
 		},
 		{
 			"topic": "GitHub Copilot alternatives",
 			"category": "evergreen",
 			"success": true,
-			"durationSeconds": 0.019146625,
-			"citationValidity": 0,
-			"trendRecallAt10": 0,
-			"oracleRecall": 0,
-			"itemCount": 0
+			"durationSeconds": 0.022213416999999992,
+			"citationValidity": 1,
+			"trendRecallAt10": 0.2,
+			"oracleRecall": 0.2,
+			"itemCount": 9
 		}
 	]
 }

--- a/scripts/eval/run.ts
+++ b/scripts/eval/run.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+	existsSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
@@ -91,6 +92,12 @@ interface TopicResult {
 	error?: string
 }
 
+/**
+ * Eval fixtures are anchored to January/February 2026.
+ * Use a wider lookback so mocked runs stay populated over time.
+ */
+const EVAL_DAYS = 60
+
 /** Load JSON fixture from the fixtures/eval directory. */
 function loadFixture<T>(name: string): T {
 	const path = join(ROOT, 'fixtures', 'eval', name)
@@ -111,6 +118,7 @@ function runTopic(
 			topic,
 			'--mock',
 			'--emit=json',
+			`--days=${EVAL_DAYS}`,
 			`--outdir=${outdir}`,
 		],
 		{ cwd: ROOT, timeout: 120_000 },
@@ -120,12 +128,20 @@ function runTopic(
 
 	let report: ReportData | null = null
 	if (success) {
-		// Find the JSON output file in outdir
+		// Prefer deterministic report artifact over raw payload files.
 		try {
-			const files = readdirSync(outdir).filter((f) => f.endsWith('.json'))
-			if (files.length > 0) {
-				const jsonPath = join(outdir, files[0]!)
-				report = JSON.parse(readFileSync(jsonPath, 'utf-8')) as ReportData
+			const reportPath = join(outdir, 'report.json')
+			if (existsSync(reportPath)) {
+				report = JSON.parse(readFileSync(reportPath, 'utf-8')) as ReportData
+			} else {
+				// Fallback for unexpected layouts: choose report*.json only.
+				const files = readdirSync(outdir).filter((f) =>
+					/^report.*\.json$/i.test(f),
+				)
+				if (files.length > 0) {
+					const jsonPath = join(outdir, files[0]!)
+					report = JSON.parse(readFileSync(jsonPath, 'utf-8')) as ReportData
+				}
 			}
 		} catch {
 			// If we can't read the output, try parsing stdout

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import * as normalize from './lib/normalize.js'
 import * as openaiReddit from './lib/openai-reddit.js'
 import * as redditEnrich from './lib/reddit-enrich.js'
 import * as render from './lib/render.js'
+import type { RedditItem, XItem, YouTubeItem } from './lib/schema.js'
 import * as schema from './lib/schema.js'
 import * as score from './lib/score.js'
 import { computeTrendScores } from './lib/trend.js'
@@ -762,7 +763,9 @@ function handleBriefingCommand(args: string[]): void {
 	// Fetch enough history for the period: daily=2 runs, weekly=8 runs.
 	const limit = period === 'weekly' ? 8 : 2
 	const runs = getHistory(topic, limit)
-	const briefing = generateBriefing(topic, runs, period)
+	// Keep core briefing logic time-free by creating timestamp at the CLI boundary.
+	const generatedAt = new Date().toISOString()
+	const briefing = generateBriefing(topic, runs, period, generatedAt)
 	process.stdout.write(renderBriefingMarkdown(briefing))
 	process.stdout.write('\n')
 }
@@ -1321,9 +1324,9 @@ async function main() {
 		scoreOpts,
 	)
 
-	const sortedReddit = score.sortItems(scoredReddit)
-	const sortedX = score.sortItems(scoredX)
-	const sortedYouTube = score.sortItems(scoredYouTube)
+	const sortedReddit = score.sortItems(scoredReddit) as RedditItem[]
+	const sortedX = score.sortItems(scoredX) as XItem[]
+	const sortedYouTube = score.sortItems(scoredYouTube) as YouTubeItem[]
 
 	const dedupedReddit = dedupe.dedupeReddit(sortedReddit)
 	const dedupedX = dedupe.dedupeX(sortedX)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * Engagement-ranked results with scoring and deduplication.
  */
 
+export { isYtDlpAvailable, searchYouTube } from './adapters/youtube.js'
 // Briefing
 export type { Briefing, BriefingPeriod } from './lib/briefing.js'
 export { generateBriefing, renderBriefingMarkdown } from './lib/briefing.js'
@@ -230,8 +231,4 @@ export {
 // xAI X
 export { parseXResponse } from './lib/xai-x.js'
 // YouTube
-export {
-	isYtDlpAvailable,
-	parseYouTubeResults,
-	youtubeEngagementScore,
-} from './lib/youtube.js'
+export { parseYouTubeResults, youtubeEngagementScore } from './lib/youtube.js'

--- a/src/lib/briefing.ts
+++ b/src/lib/briefing.ts
@@ -60,16 +60,29 @@ interface SummaryJson {
  * @param entry - The run history entry to parse.
  */
 function parseSummaryJson(entry: RunHistoryEntry): SummaryJson | null {
-	// RunHistoryEntry does not expose summary_json in the public type --
-	// it is stored in the DB but omitted from the mapped interface.
-	// We cast to access it when present (e.g., tests that pass enriched rows).
-	const raw = (entry as RunHistoryEntry & { summaryJson?: string | null })
-		.summaryJson
+	const raw = entry.summaryJson
 	if (!raw) return null
 	try {
 		const parsed = JSON.parse(raw) as unknown
 		if (typeof parsed !== 'object' || parsed === null) return null
-		return parsed as SummaryJson
+		const obj = parsed as Record<string, unknown>
+		// Validate entities shape -- each field must be an array or absent.
+		// Malformed payloads (e.g. { handles: null }) would crash renderBriefingMarkdown.
+		if (obj.entities != null) {
+			if (typeof obj.entities !== 'object' || Array.isArray(obj.entities)) {
+				return { ...(obj as SummaryJson), entities: undefined }
+			}
+			const ent = obj.entities as Record<string, unknown>
+			const keys = ['handles', 'subreddits', 'hashtags', 'terms'] as const
+			for (const k of keys) {
+				// Reject if the key exists but is not an array (including null).
+				// renderBriefingMarkdown calls .length on each field.
+				if (k in ent && !Array.isArray(ent[k])) {
+					return { ...(obj as SummaryJson), entities: undefined }
+				}
+			}
+		}
+		return obj as SummaryJson
 	} catch {
 		return null
 	}
@@ -95,14 +108,14 @@ function parseSummaryJson(entry: RunHistoryEntry): SummaryJson | null {
  * @param topic   - The research topic.
  * @param runs    - Run history entries ordered most-recent first.
  * @param period  - Reporting period ('daily' or 'weekly').
+ * @param generatedAt - ISO timestamp supplied by caller.
  */
 export function generateBriefing(
 	topic: string,
 	runs: RunHistoryEntry[],
 	period: BriefingPeriod,
+	generatedAt: string,
 ): Briefing {
-	const generatedAt = new Date().toISOString()
-
 	if (runs.length === 0) {
 		return {
 			topic,

--- a/src/lib/reddit-enrich.ts
+++ b/src/lib/reddit-enrich.ts
@@ -153,6 +153,7 @@ export async function enrichRedditItem(
 	mockThreadData: unknown | null = null,
 ): Promise<Record<string, unknown>> {
 	const url = (item.url as string) ?? ''
+	const isMock = mockThreadData !== null
 
 	const threadData = await fetchThreadData(url, mockThreadData)
 	if (!threadData) return item
@@ -170,7 +171,12 @@ export async function enrichRedditItem(
 
 		const createdUtc = submission.created_utc as number | undefined
 		if (createdUtc) {
-			item.date = timestampToDate(createdUtc)
+			const parsedDate = timestampToDate(createdUtc)
+			// In mock mode, preserve fixture dates if they already exist so
+			// enrichment doesn't collapse all items onto sample-thread timestamps.
+			if (parsedDate && (!isMock || !item.date)) {
+				item.date = parsedDate
+			}
 		}
 	}
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -87,25 +87,6 @@ export interface YouTubeItem {
 	momentum?: number
 }
 
-/** Normalized YouTube video item. */
-export interface YouTubeItem {
-	id: string
-	title: string
-	url: string
-	channel: string
-	date: string | null
-	date_confidence: string
-	views: number
-	likes: number
-	comments: number
-	transcript_snippet: string
-	engagement: Engagement | null
-	relevance: number
-	why_relevant: string
-	subs: SubScores
-	score: number
-}
-
 /** Normalized web search item (no engagement metrics). */
 export interface WebSearchItem {
 	id: string

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -25,20 +25,18 @@ const WEBSEARCH_SOURCE_PENALTY = 15
 const WEBSEARCH_VERIFIED_BONUS = 10
 const WEBSEARCH_NO_DATE_PENALTY = 20
 
-// Trend weight (when trend data is available)
+// Default trend weight (when trend data is available)
 const WEIGHT_TREND = 0.1
-// Adjusted weights when trend data is present (sum to 0.9)
-const TREND_WEIGHT_RELEVANCE = 0.405
-const TREND_WEIGHT_RECENCY = 0.225
-const TREND_WEIGHT_ENGAGEMENT = 0.27
-
-// Adjusted websearch weights when trend data is present (sum to 0.9)
-const TREND_WEBSEARCH_WEIGHT_RELEVANCE = 0.495
-const TREND_WEBSEARCH_WEIGHT_RECENCY = 0.405
 
 // Default engagement score for unknown
 const DEFAULT_ENGAGEMENT = 35
 const UNKNOWN_ENGAGEMENT_PENALTY = 10
+
+/** Options for score functions. */
+export interface ScoreOptions {
+	intentWeights?: IntentWeights
+	trendWeight?: number
+}
 
 /** Safe log1p that handles null and negative values. */
 function log1pSafe(x: number | null | undefined): number {
@@ -108,9 +106,11 @@ export function scoreRedditItems(
 	items: RedditItem[],
 	maxDays = 30,
 	trendScores?: Map<string, TrendScore>,
-	intentWeights?: IntentWeights,
+	opts?: ScoreOptions,
 ): RedditItem[] {
 	if (items.length === 0) return items
+	const intentWeights = opts?.intentWeights
+	const trendWeight = opts?.trendWeight ?? WEIGHT_TREND
 
 	const engRaw = items.map((item) =>
 		computeRedditEngagementRaw(item.engagement),
@@ -135,12 +135,12 @@ export function scoreRedditItems(
 		let overall: number
 		if (intentWeights) {
 			if (ts) {
-				// Trend takes 10%; intent weights scaled to 90%
+				const baseWeight = 1 - trendWeight
 				overall =
-					intentWeights.relevance * 0.9 * relScore +
-					intentWeights.recency * 0.9 * recScore +
-					intentWeights.engagement * 0.9 * engScore +
-					0.1 * ts.trendScore * 100
+					intentWeights.relevance * baseWeight * relScore +
+					intentWeights.recency * baseWeight * recScore +
+					intentWeights.engagement * baseWeight * engScore +
+					trendWeight * ts.trendScore * 100
 			} else {
 				overall =
 					intentWeights.relevance * relScore +
@@ -148,11 +148,21 @@ export function scoreRedditItems(
 					intentWeights.engagement * engScore
 			}
 		} else if (ts) {
+			const baseWeight = 1 - trendWeight
 			overall =
-				TREND_WEIGHT_RELEVANCE * relScore +
-				TREND_WEIGHT_RECENCY * recScore +
-				TREND_WEIGHT_ENGAGEMENT * engScore +
-				WEIGHT_TREND * ts.trendScore * 100
+				(WEIGHT_RELEVANCE /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					relScore +
+				(WEIGHT_RECENCY /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					recScore +
+				(WEIGHT_ENGAGEMENT /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					engScore +
+				trendWeight * ts.trendScore * 100
 		} else {
 			overall =
 				WEIGHT_RELEVANCE * relScore +
@@ -165,6 +175,12 @@ export function scoreRedditItems(
 		else if (item.date_confidence === 'med') overall -= 5
 
 		item.score = Math.max(0, Math.min(100, Math.floor(overall)))
+
+		if (ts) {
+			item.trend_score = Math.round(ts.trendScore * 100)
+			item.momentum = ts.momentum
+			item.subs.trend_score = Math.round(ts.trendScore * 100)
+		}
 	}
 
 	return items
@@ -181,9 +197,11 @@ export function scoreXItems(
 	items: XItem[],
 	maxDays = 30,
 	trendScores?: Map<string, TrendScore>,
-	intentWeights?: IntentWeights,
+	opts?: ScoreOptions,
 ): XItem[] {
 	if (items.length === 0) return items
+	const intentWeights = opts?.intentWeights
+	const trendWeight = opts?.trendWeight ?? WEIGHT_TREND
 
 	const engRaw = items.map((item) => computeXEngagementRaw(item.engagement))
 	const engNormalized = normalizeTo100(engRaw)
@@ -206,12 +224,12 @@ export function scoreXItems(
 		let overall: number
 		if (intentWeights) {
 			if (ts) {
-				// Trend takes 10%; intent weights scaled to 90%
+				const baseWeight = 1 - trendWeight
 				overall =
-					intentWeights.relevance * 0.9 * relScore +
-					intentWeights.recency * 0.9 * recScore +
-					intentWeights.engagement * 0.9 * engScore +
-					0.1 * ts.trendScore * 100
+					intentWeights.relevance * baseWeight * relScore +
+					intentWeights.recency * baseWeight * recScore +
+					intentWeights.engagement * baseWeight * engScore +
+					trendWeight * ts.trendScore * 100
 			} else {
 				overall =
 					intentWeights.relevance * relScore +
@@ -219,11 +237,21 @@ export function scoreXItems(
 					intentWeights.engagement * engScore
 			}
 		} else if (ts) {
+			const baseWeight = 1 - trendWeight
 			overall =
-				TREND_WEIGHT_RELEVANCE * relScore +
-				TREND_WEIGHT_RECENCY * recScore +
-				TREND_WEIGHT_ENGAGEMENT * engScore +
-				WEIGHT_TREND * ts.trendScore * 100
+				(WEIGHT_RELEVANCE /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					relScore +
+				(WEIGHT_RECENCY /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					recScore +
+				(WEIGHT_ENGAGEMENT /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					engScore +
+				trendWeight * ts.trendScore * 100
 		} else {
 			overall =
 				WEIGHT_RELEVANCE * relScore +
@@ -236,6 +264,12 @@ export function scoreXItems(
 		else if (item.date_confidence === 'med') overall -= 5
 
 		item.score = Math.max(0, Math.min(100, Math.floor(overall)))
+
+		if (ts) {
+			item.trend_score = Math.round(ts.trendScore * 100)
+			item.momentum = ts.momentum
+			item.subs.trend_score = Math.round(ts.trendScore * 100)
+		}
 	}
 
 	return items
@@ -252,9 +286,11 @@ export function scoreWebsearchItems(
 	items: WebSearchItem[],
 	maxDays = 30,
 	trendScores?: Map<string, TrendScore>,
-	intentWeights?: IntentWeights,
+	opts?: ScoreOptions,
 ): WebSearchItem[] {
 	if (items.length === 0) return items
+	const intentWeights = opts?.intentWeights
+	const trendWeight = opts?.trendWeight ?? WEIGHT_TREND
 
 	for (const item of items) {
 		const relScore = Number.isFinite(item.relevance)
@@ -276,19 +312,26 @@ export function scoreWebsearchItems(
 			const recShare = relPlusRec > 0 ? intentWeights.recency / relPlusRec : 0.5
 
 			if (ts) {
-				// Trend takes 10%; intent weights scaled to 90%
+				const baseWeight = 1 - trendWeight
 				overall =
-					relShare * 0.9 * relScore +
-					recShare * 0.9 * recScore +
-					0.1 * ts.trendScore * 100
+					relShare * baseWeight * relScore +
+					recShare * baseWeight * recScore +
+					trendWeight * ts.trendScore * 100
 			} else {
 				overall = relShare * relScore + recShare * recScore
 			}
 		} else if (ts) {
+			const baseWeight = 1 - trendWeight
 			overall =
-				TREND_WEBSEARCH_WEIGHT_RELEVANCE * relScore +
-				TREND_WEBSEARCH_WEIGHT_RECENCY * recScore +
-				WEIGHT_TREND * ts.trendScore * 100
+				(WEBSEARCH_WEIGHT_RELEVANCE /
+					(WEBSEARCH_WEIGHT_RELEVANCE + WEBSEARCH_WEIGHT_RECENCY)) *
+					baseWeight *
+					relScore +
+				(WEBSEARCH_WEIGHT_RECENCY /
+					(WEBSEARCH_WEIGHT_RELEVANCE + WEBSEARCH_WEIGHT_RECENCY)) *
+					baseWeight *
+					recScore +
+				trendWeight * ts.trendScore * 100
 		} else {
 			overall =
 				WEBSEARCH_WEIGHT_RELEVANCE * relScore +
@@ -302,6 +345,12 @@ export function scoreWebsearchItems(
 			overall -= WEBSEARCH_NO_DATE_PENALTY
 
 		item.score = Math.max(0, Math.min(100, Math.floor(overall)))
+
+		if (ts) {
+			item.trend_score = Math.round(ts.trendScore * 100)
+			item.momentum = ts.momentum
+			item.subs.trend_score = Math.round(ts.trendScore * 100)
+		}
 	}
 
 	return items
@@ -327,9 +376,11 @@ export function scoreYouTubeItems(
 	items: YouTubeItem[],
 	maxDays = 30,
 	trendScores?: Map<string, TrendScore>,
-	intentWeights?: IntentWeights,
+	opts?: ScoreOptions,
 ): YouTubeItem[] {
 	if (items.length === 0) return items
+	const intentWeights = opts?.intentWeights
+	const trendWeight = opts?.trendWeight ?? WEIGHT_TREND
 
 	const engRaw = items.map((item) => computeYouTubeEngagementRaw(item))
 	const engNormalized = normalizeTo100(engRaw)
@@ -356,12 +407,12 @@ export function scoreYouTubeItems(
 		let overall: number
 		if (intentWeights) {
 			if (ts) {
-				// Trend takes 10%; intent weights scaled to 90%
+				const baseWeight = 1 - trendWeight
 				overall =
-					intentWeights.relevance * 0.9 * relScore +
-					intentWeights.recency * 0.9 * recScore +
-					intentWeights.engagement * 0.9 * engScore +
-					0.1 * ts.trendScore * 100
+					intentWeights.relevance * baseWeight * relScore +
+					intentWeights.recency * baseWeight * recScore +
+					intentWeights.engagement * baseWeight * engScore +
+					trendWeight * ts.trendScore * 100
 			} else {
 				overall =
 					intentWeights.relevance * relScore +
@@ -369,11 +420,21 @@ export function scoreYouTubeItems(
 					intentWeights.engagement * engScore
 			}
 		} else if (ts) {
+			const baseWeight = 1 - trendWeight
 			overall =
-				TREND_WEIGHT_RELEVANCE * relScore +
-				TREND_WEIGHT_RECENCY * recScore +
-				TREND_WEIGHT_ENGAGEMENT * engScore +
-				WEIGHT_TREND * ts.trendScore * 100
+				(WEIGHT_RELEVANCE /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					relScore +
+				(WEIGHT_RECENCY /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					recScore +
+				(WEIGHT_ENGAGEMENT /
+					(WEIGHT_RELEVANCE + WEIGHT_RECENCY + WEIGHT_ENGAGEMENT)) *
+					baseWeight *
+					engScore +
+				trendWeight * ts.trendScore * 100
 		} else {
 			overall =
 				WEIGHT_RELEVANCE * relScore +
@@ -385,6 +446,12 @@ export function scoreYouTubeItems(
 		else if (item.date_confidence === 'med') overall -= 5
 
 		item.score = Math.max(0, Math.min(100, Math.floor(overall)))
+
+		if (ts) {
+			item.trend_score = Math.round(ts.trendScore * 100)
+			item.momentum = ts.momentum
+			item.subs.trend_score = Math.round(ts.trendScore * 100)
+		}
 	}
 
 	return items
@@ -392,8 +459,8 @@ export function scoreYouTubeItems(
 
 /** Sort items by score (descending), then date, then source priority. */
 export function sortItems(
-	items: (RedditItem | XItem | WebSearchItem)[],
-): (RedditItem | XItem | WebSearchItem)[] {
+	items: (RedditItem | XItem | WebSearchItem | YouTubeItem)[],
+): (RedditItem | XItem | WebSearchItem | YouTubeItem)[] {
 	return [...items].sort((a, b) => {
 		// Primary: score descending
 		if (a.score !== b.score) return b.score - a.score
@@ -415,8 +482,11 @@ export function sortItems(
 	})
 }
 
-function getSourcePriority(item: RedditItem | XItem | WebSearchItem): number {
+function getSourcePriority(
+	item: RedditItem | XItem | WebSearchItem | YouTubeItem,
+): number {
 	if ('subreddit' in item) return 0 // Reddit
 	if ('author_handle' in item) return 1 // X
-	return 2 // WebSearch
+	if ('channel' in item) return 2 // YouTube
+	return 3 // WebSearch
 }

--- a/src/lib/watchlist.ts
+++ b/src/lib/watchlist.ts
@@ -30,6 +30,8 @@ export interface RunHistoryEntry {
 	itemCount: number
 	status: 'success' | 'error'
 	errorMessage: string | null
+	/** Raw serialized entity snapshot from DB; optional for legacy rows/tests. */
+	summaryJson?: string | null
 }
 
 /** Input shape for `recordRun`. */
@@ -61,6 +63,7 @@ interface RunHistoryRow {
 	item_count: number
 	status: string
 	error_message: string | null
+	summary_json: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +157,7 @@ export function getHistory(
 	const conn = db ?? getDb()
 	const rows = conn
 		.query<RunHistoryRow, [string, number]>(
-			`SELECT id, topic, ran_at, duration_ms, item_count, status, error_message
+			`SELECT id, topic, ran_at, duration_ms, item_count, status, error_message, summary_json
        FROM run_history
        WHERE topic = ?
        ORDER BY ran_at DESC, id DESC
@@ -170,6 +173,7 @@ export function getHistory(
 		itemCount: r.item_count,
 		status: r.status as 'success' | 'error',
 		errorMessage: r.error_message,
+		summaryJson: r.summary_json,
 	}))
 }
 

--- a/tests/briefing.test.ts
+++ b/tests/briefing.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, expect, test } from 'bun:test'
-import { generateBriefing, renderBriefingMarkdown } from '../src/lib/briefing'
+import {
+	generateBriefing as generateBriefingCore,
+	renderBriefingMarkdown,
+} from '../src/lib/briefing'
 import {
 	computeDelta,
 	detectFallingVoices,
@@ -19,6 +22,13 @@ import {
 } from '../src/lib/delta'
 import type { EntityResult, ExtractedEntity } from '../src/lib/entity-extract'
 import type { RunHistoryEntry } from '../src/lib/watchlist'
+
+const TEST_GENERATED_AT = '2026-02-20T00:00:00.000Z'
+
+/** Helper to keep briefing tests focused on content, not wall-clock time. */
+function makeBriefing(topic: string, runs: RunHistoryEntry[], period: 'daily' | 'weekly') {
+	return generateBriefingCore(topic, runs, period, TEST_GENERATED_AT)
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -64,14 +74,14 @@ function makeRun(id: number, ranAt: string, itemCount = 10): RunHistoryEntry {
 
 /**
  * Makes a RunHistoryEntry with a serialised summary_json payload.
- * We cast to include the summaryJson property expected by briefing.ts.
+ * `summaryJson` is optional on RunHistoryEntry, but included here explicitly.
  */
 function makeRunWithSummary(
 	id: number,
 	ranAt: string,
 	entities: EntityResult | null,
 	itemCount = 10,
-): RunHistoryEntry & { summaryJson: string } {
+): RunHistoryEntry {
 	return {
 		id,
 		topic: 'AI trends',
@@ -465,7 +475,7 @@ describe('computeDelta', () => {
 
 describe('generateBriefing', () => {
 	test('0 runs: returns empty briefing with null fields', () => {
-		const briefing = generateBriefing('AI trends', [], 'daily')
+		const briefing = makeBriefing('AI trends', [], 'daily')
 		expect(briefing.topic).toBe('AI trends')
 		expect(briefing.period).toBe('daily')
 		expect(briefing.currentRun).toBeNull()
@@ -475,15 +485,14 @@ describe('generateBriefing', () => {
 		expect(briefing.itemCount).toBe(0)
 	})
 
-	test('0 runs: generatedAt is a non-empty ISO string', () => {
-		const briefing = generateBriefing('test', [], 'daily')
-		expect(briefing.generatedAt).toBeTruthy()
-		expect(briefing.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+	test('generatedAt uses caller-provided timestamp', () => {
+		const briefing = makeBriefing('test', [], 'daily')
+		expect(briefing.generatedAt).toBe(TEST_GENERATED_AT)
 	})
 
 	test('1 run without summary: currentRun set, no delta', () => {
 		const run = makeRun(1, '2026-02-18T10:00:00Z', 15)
-		const briefing = generateBriefing('AI trends', [run], 'daily')
+		const briefing = makeBriefing('AI trends', [run], 'daily')
 		expect(briefing.currentRun).not.toBeNull()
 		expect(briefing.previousRun).toBeNull()
 		expect(briefing.delta).toBeNull()
@@ -493,7 +502,7 @@ describe('generateBriefing', () => {
 
 	test('1 run with entities in summary: topEntities populated', () => {
 		const run = makeRunWithSummary(1, '2026-02-18T10:00:00Z', fullResult(), 20)
-		const briefing = generateBriefing('AI trends', [run], 'daily')
+		const briefing = makeBriefing('AI trends', [run], 'daily')
 		expect(briefing.topEntities).not.toBeNull()
 		expect(briefing.topEntities?.handles).toHaveLength(1)
 		expect(briefing.itemCount).toBe(20)
@@ -509,7 +518,7 @@ describe('generateBriefing', () => {
 		}
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRunWithSummary(1, '2026-02-18T10:00:00Z', prev)
-		const briefing = generateBriefing('AI trends', [run1, run2], 'daily')
+		const briefing = makeBriefing('AI trends', [run1, run2], 'daily')
 		expect(briefing.delta).not.toBeNull()
 		// r/machinelearning, #claude, transformer are new
 		expect((briefing.delta?.newEntities.length ?? 0) >= 1).toBe(true)
@@ -519,7 +528,7 @@ describe('generateBriefing', () => {
 		const curr = fullResult()
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRun(1, '2026-02-18T10:00:00Z')
-		const briefing = generateBriefing('AI trends', [run1, run2], 'daily')
+		const briefing = makeBriefing('AI trends', [run1, run2], 'daily')
 		// No entity data in previous -- delta cannot be computed
 		expect(briefing.delta).toBeNull()
 	})
@@ -529,7 +538,7 @@ describe('generateBriefing', () => {
 			...makeRun(1, '2026-02-18T10:00:00Z'),
 			summaryJson: 'not-valid-json',
 		}
-		const briefing = generateBriefing('AI trends', [run], 'daily')
+		const briefing = makeBriefing('AI trends', [run], 'daily')
 		expect(briefing.topEntities).toBeNull()
 	})
 
@@ -538,13 +547,43 @@ describe('generateBriefing', () => {
 			...makeRun(1, '2026-02-18T10:00:00Z'),
 			summaryJson: JSON.stringify({ itemCount: 5 }),
 		}
-		const briefing = generateBriefing('AI trends', [run], 'daily')
+		const briefing = makeBriefing('AI trends', [run], 'daily')
 		expect(briefing.topEntities).toBeNull()
 		expect(briefing.itemCount).toBe(5)
 	})
 
+	test('malformed entities (null fields) are dropped gracefully', () => {
+		const run: RunHistoryEntry & { summaryJson: string } = {
+			...makeRun(1, '2026-02-18T10:00:00Z'),
+			summaryJson: JSON.stringify({ entities: { handles: null, subreddits: [] }, itemCount: 5 }),
+		}
+		const briefing = makeBriefing('AI trends', [run], 'daily')
+		// Malformed entities should be dropped, not crash
+		expect(briefing.topEntities).toBeNull()
+		expect(briefing.itemCount).toBe(5)
+	})
+
+	test('entities as array (wrong shape) are dropped gracefully', () => {
+		const run: RunHistoryEntry & { summaryJson: string } = {
+			...makeRun(1, '2026-02-18T10:00:00Z'),
+			summaryJson: JSON.stringify({ entities: ['bad'], itemCount: 3 }),
+		}
+		const briefing = makeBriefing('AI trends', [run], 'daily')
+		expect(briefing.topEntities).toBeNull()
+	})
+
+	test('malformed entities do not crash renderBriefingMarkdown', () => {
+		const run: RunHistoryEntry & { summaryJson: string } = {
+			...makeRun(1, '2026-02-18T10:00:00Z'),
+			summaryJson: JSON.stringify({ entities: { handles: 'not-array' }, itemCount: 2 }),
+		}
+		const briefing = makeBriefing('AI trends', [run], 'daily')
+		const md = renderBriefingMarkdown(briefing)
+		expect(md).toContain('No entity data available.')
+	})
+
 	test('weekly period is preserved in briefing', () => {
-		const briefing = generateBriefing('Bun 1.2', [], 'weekly')
+		const briefing = makeBriefing('Bun 1.2', [], 'weekly')
 		expect(briefing.period).toBe('weekly')
 	})
 })
@@ -555,14 +594,14 @@ describe('generateBriefing', () => {
 
 describe('renderBriefingMarkdown', () => {
 	test('renders header with topic and period', () => {
-		const briefing = generateBriefing('Claude Code', [], 'daily')
+		const briefing = makeBriefing('Claude Code', [], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('# Briefing: Claude Code')
 		expect(md).toContain('**Period**: daily')
 	})
 
 	test('renders all expected section headings', () => {
-		const briefing = generateBriefing('test', [], 'daily')
+		const briefing = makeBriefing('test', [], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('## Summary')
 		expect(md).toContain("## What's New")
@@ -573,7 +612,7 @@ describe('renderBriefingMarkdown', () => {
 	})
 
 	test('0 runs: shows appropriate no-data messages', () => {
-		const briefing = generateBriefing('test', [], 'daily')
+		const briefing = makeBriefing('test', [], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('No runs recorded yet.')
 		expect(md).toContain('No new entities detected.')
@@ -585,14 +624,14 @@ describe('renderBriefingMarkdown', () => {
 
 	test('single run shows "No previous run"', () => {
 		const run = makeRun(1, '2026-02-19T10:00:00Z')
-		const briefing = generateBriefing('test', [run], 'daily')
+		const briefing = makeBriefing('test', [run], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('No previous run')
 	})
 
 	test('single run shows latest run timestamp and item count', () => {
 		const run = makeRun(1, '2026-02-19T10:00:00Z', 42)
-		const briefing = generateBriefing('test', [run], 'daily')
+		const briefing = makeBriefing('test', [run], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('2026-02-19T10:00:00Z')
 		expect(md).toContain('42 items')
@@ -613,7 +652,7 @@ describe('renderBriefingMarkdown', () => {
 		}
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRunWithSummary(1, '2026-02-18T10:00:00Z', prev)
-		const briefing = generateBriefing('test', [run1, run2], 'daily')
+		const briefing = makeBriefing('test', [run1, run2], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('+500')
 		expect(md).toContain('@alice')
@@ -634,14 +673,14 @@ describe('renderBriefingMarkdown', () => {
 		}
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRunWithSummary(1, '2026-02-18T10:00:00Z', prev)
-		const briefing = generateBriefing('test', [run1, run2], 'daily')
+		const briefing = makeBriefing('test', [run1, run2], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('-600')
 	})
 
 	test('renders top entities from the latest run', () => {
 		const run = makeRunWithSummary(1, '2026-02-19T10:00:00Z', fullResult())
-		const briefing = generateBriefing('test', [run], 'daily')
+		const briefing = makeBriefing('test', [run], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('@alice')
 		expect(md).toContain('r/machinelearning')
@@ -653,7 +692,7 @@ describe('renderBriefingMarkdown', () => {
 		const curr = fullResult()
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRunWithSummary(1, '2026-02-18T10:00:00Z', curr)
-		const briefing = generateBriefing('test', [run1, run2], 'daily')
+		const briefing = makeBriefing('test', [run1, run2], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('No new entities detected.')
 	})
@@ -668,7 +707,7 @@ describe('renderBriefingMarkdown', () => {
 		}
 		const run1 = makeRunWithSummary(2, '2026-02-19T10:00:00Z', curr)
 		const run2 = makeRunWithSummary(1, '2026-02-18T10:00:00Z', prev)
-		const briefing = generateBriefing('test', [run1, run2], 'daily')
+		const briefing = makeBriefing('test', [run1, run2], 'daily')
 		const md = renderBriefingMarkdown(briefing)
 		expect(md).toContain('@newuser')
 	})

--- a/tests/watchlist.test.ts
+++ b/tests/watchlist.test.ts
@@ -261,6 +261,23 @@ describe('recordRun', () => {
 		db.close()
 	})
 
+	test('includes summaryJson when present in run_history', () => {
+		const db = makeDb()
+		addTopic('summary-topic', undefined, db)
+		recordRun(
+			'summary-topic',
+			{
+				...SUCCESS_RUN,
+				summaryJson: JSON.stringify({ itemCount: 10, entities: { handles: [] } }),
+			},
+			db,
+		)
+		const [entry] = getHistory('summary-topic', 1, db)
+		expect(entry?.summaryJson).toBeTruthy()
+		expect(typeof entry?.summaryJson).toBe('string')
+		db.close()
+	})
+
 	test('records an error run with status=error and message', () => {
 		const db = makeDb()
 		addTopic('error-topic', undefined, db)


### PR DESCRIPTION
## Summary
Implements **PR-010 (Briefing + Delta Intelligence)** from the hybrid retrieval plan.

This PR adds delta computation and markdown briefing generation over persisted watchlist history.

## Why
Persistent runs are most useful when transformed into actionable change summaries. Delta + briefing layers surface what is new, rising, and falling between runs.

## What Changed
- Added `src/lib/delta.ts`
  - `flattenEntities(...)`
  - `detectNewEntities(...)`
  - `detectGoneEntities(...)`
  - `detectRisingVoices(...)`
  - `detectFallingVoices(...)`
  - `computeDelta(...)`
  - `DeltaEntry`, `DeltaReport` types
- Added `src/lib/briefing.ts`
  - `generateBriefing(topic, runs, period)`
  - `renderBriefingMarkdown(briefing)`
  - Daily/weekly period support
  - Structured sections: “What’s New”, “Rising”, “Falling”
- Updated `src/cli.ts`
  - Added briefing command:
    - `briefing "topic" [--period=daily|weekly]`
- Updated exports in `src/index.ts`
- Added `tests/briefing.test.ts`
  - Delta edge cases and ordering checks
  - Briefing generation across 0/1/multi-run scenarios
  - Markdown rendering assertions

## Behavior and Compatibility
- Briefing functionality is additive and depends on existing watchlist history.
- Existing non-watchlist CLI flows remain unchanged.

## Validation
- `bun run validate`
- `bun run eval:pr`

## Risk
Medium-low. New analytics/rendering layer is isolated and heavily unit tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New briefing command: generate Markdown briefings (daily/weekly) for topics with timestamp and item counts
  * Briefings include Summary, What’s New, Rising, Falling, Gone, and Top Entities with engagement deltas

* **Tests**
  * Added comprehensive tests covering delta detection, briefing generation, and rendering across scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->