### PR TITLE
chore(ci): add eval release gates and update docs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -151,6 +151,23 @@ jobs:
           min-branches: '80'
           min-functions: '80'
 
+  eval:
+    name: Eval benchmark
+    runs-on: ubuntu-latest
+    needs: [test]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Standard env
+        uses: ./.github/actions/standard-ci-env
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run eval benchmark (PR mode)
+        run: bun run eval:pr
+
   quality:
     name: Repo quality (delta since main)
     runs-on: ubuntu-latest
@@ -202,7 +219,7 @@ jobs:
   gate:
     name: All checks passed
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, quality, lint-scripts]
+    needs: [lint, typecheck, test, quality, lint-scripts, eval]
     if: always()
     timeout-minutes: 5
     steps:
@@ -217,6 +234,7 @@ jobs:
             echo "  Tests + Coverage: ${{ needs.test.result }}"
             echo "  Repo quality: ${{ needs.quality.result }}"
             echo "  Lint Shell Scripts: ${{ needs.lint-scripts.result }}"
+            echo "  Eval benchmark: ${{ needs.eval.result }}"
             exit 1
           fi
           echo "All prerequisite PR quality jobs succeeded."
@@ -234,6 +252,7 @@ jobs:
             echo "| Tests + Coverage | ${{ needs.test.result }} |"
             echo "| Repo quality (delta since main) | ${{ needs.quality.result }} |"
             echo "| Lint Shell Scripts | ${{ needs.lint-scripts.result }} |"
+            echo "| Eval benchmark | ${{ needs.eval.result }} |"
             echo
             echo "### Coverage"
             echo

--- a/README.md
+++ b/README.md
@@ -1,399 +1,142 @@
-# bun-typescript-starter
+# @side-quest/last-30-days
 
-Modern TypeScript starter template with enterprise-grade tooling.
+Research any topic from the last 30 days across Reddit, X, YouTube, and web search. Engagement-ranked results with scoring, deduplication, and trend analysis.
 
-## Features
-
-- **Bun** - Fast all-in-one JavaScript runtime and toolkit
-- **TypeScript 5.9+** - Strict mode, ESM only
-- **Biome** - Lightning-fast linting and formatting (replaces ESLint + Prettier)
-- **Vitest** - Fast unit testing with native Bun support
-- **Changesets** - Automated versioning and changelog generation
-- **GitHub Actions** - Comprehensive CI/CD with OIDC npm publishing
-- **Conventional Commits** - Enforced via commitlint + Husky
-
-## Quick Start
-
-### Prerequisites
-
-- [Bun](https://bun.sh) installed (`curl -fsSL https://bun.sh/install | bash`)
-- [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`)
-- [npm account](https://www.npmjs.com) with a granular access token (see [NPM Token Setup](#npm-token-setup))
-
-### Option A: GitHub CLI (Recommended)
-
-Create a new repo from this template and set it up in one command:
+## Installation
 
 ```bash
-# Create repo from template
-gh repo create myusername/my-lib --template nathanvale/bun-typescript-starter --public --clone
-
-# Run setup (interactive)
-cd my-lib
-bun run setup
+bun add @side-quest/last-30-days
 ```
 
-### Option B: CLI Mode (Non-Interactive)
-
-For automated/scripted setups, pass all arguments via CLI flags:
+Or use as a CLI:
 
 ```bash
-# Create repo from template
-gh repo create myusername/my-lib --template nathanvale/bun-typescript-starter --public --clone
-cd my-lib
-
-# Run setup with all arguments (no prompts)
-bun run setup -- \
-  --name "@myusername/my-lib" \
-  --description "My awesome library" \
-  --author "Your Name" \
-  --yes
-```
-
-### Option C: degit
-
-```bash
-npx degit nathanvale/bun-typescript-starter my-lib
-cd my-lib
-bun run setup
-```
-
-## Setup Script
-
-The setup script configures your project and optionally creates the GitHub repository with all settings pre-configured.
-
-### Interactive Mode
-
-```bash
-bun run setup
-```
-
-Prompts for:
-- Package name (e.g., `@myusername/my-lib` or `my-lib`)
-- Repository name
-- GitHub username/org
-- Project description
-- Author name
-
-### CLI Mode
-
-```bash
-bun run setup -- [options]
-```
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--name` | `-n` | Package name (e.g., `@myusername/my-lib`) |
-| `--repo` | `-r` | Repository name (defaults to package name) |
-| `--user` | `-u` | GitHub username/org (auto-detected from `gh`) |
-| `--description` | `-d` | Project description |
-| `--author` | `-a` | Author name |
-| `--yes` | `-y` | Skip confirmation prompts (auto-yes) |
-| `--no-github` | | Skip GitHub repo creation/configuration |
-| `--help` | `-h` | Show help |
-
-### What Setup Does
-
-1. **Configures files** - Replaces placeholders in `package.json` and `.changeset/config.json`
-2. **Installs dependencies** - Runs `bun install`
-3. **Creates initial commit** - Commits all configured files
-4. **Creates GitHub repo** (if it doesn't exist) - Uses `gh repo create`
-5. **Configures GitHub settings**:
-   - Enables workflow permissions for PR creation
-   - Sets squash-only merging
-   - Enables auto-delete branches
-   - Enables auto-merge
-   - Configures branch protection rules
-
-## Complete Setup Guide
-
-This guide walks through the full process of creating a new package and publishing it to npm.
-
-### Step 1: Create Repository
-
-```bash
-# Create and clone from template
-gh repo create myusername/my-lib --template nathanvale/bun-typescript-starter --public --clone
-cd my-lib
-```
-
-### Step 2: Run Setup
-
-```bash
-# Interactive mode
-bun run setup
-
-# Or non-interactive mode
-bun run setup -- \
-  --name "@myusername/my-lib" \
-  --description "My awesome library" \
-  --author "Your Name" \
-  --yes
-```
-
-### Step 3: Install Changeset Bot
-
-Install the [Changeset Bot](https://github.com/apps/changeset-bot) GitHub App on your repo. It comments on every PR with changeset status so you know at a glance whether version bumps are queued.
-
-1. Visit https://github.com/apps/changeset-bot
-2. Click **Install** and select your repository
-3. Grant the requested permissions (pull request read/write, contents read-only)
-
-> The bot works alongside the `autogenerate-changeset.yml` workflow — the bot comments instantly, and the workflow auto-generates a changeset file if one is missing.
-
-### Step 4: Configure NPM Token
-
-Before publishing, you need to add your npm token to GitHub secrets.
-
-#### Create npm Granular Access Token
-
-1. Go to [npmjs.com](https://www.npmjs.com) → Access Tokens → Generate New Token → **Granular Access Token**
-
-2. Configure the token:
-   - **Token name:** `github-actions-publish` (or any name)
-   - **Expiration:** 90 days (maximum for granular tokens)
-   - **Packages and scopes:** Select "All packages" for new packages, or specific packages for existing ones
-   - **Permissions:** Read and write
-   - **IMPORTANT:** Check **"Bypass two-factor authentication for automation"**
-
-   > Without "Bypass 2FA", CI/CD publishing will fail with "Access token expired or revoked"
-
-3. Copy the token (starts with `npm_`)
-
-#### Add Token to GitHub Secrets
-
-```bash
-# If you have NPM_TOKEN in your environment
-echo "$NPM_TOKEN" | gh secret set NPM_TOKEN --repo myusername/my-lib
-
-# Or set it interactively
-gh secret set NPM_TOKEN --repo myusername/my-lib
-# Paste your token when prompted
-```
-
-### Step 5: Create Initial Release
-
-Create a changeset describing your initial release:
-
-```bash
-# Create a feature branch
-git checkout -b feat/initial-release
-
-# Create changeset file
-mkdir -p .changeset
-cat > .changeset/initial-release.md << 'EOF'
----
-"@myusername/my-lib": minor
----
-
-Initial release
-EOF
-
-# Commit and push
-git add .changeset/initial-release.md
-git commit -m "chore: add changeset for initial release"
-git push -u origin feat/initial-release
-
-# Create PR
-gh pr create --title "chore: add changeset for initial release" --body "Initial release"
-```
-
-### Step 6: Merge and Publish
-
-1. **Wait for CI checks** to pass on your PR
-2. **Merge the PR** - This triggers the changesets workflow
-3. **A "Version Packages" PR** will be automatically created
-4. **Merge the Version PR** - This triggers the publish workflow
-5. **Package is published to npm!**
-
-```bash
-# Check your package
-npm view @myusername/my-lib
-```
-
-### Step 7: Configure OIDC Trusted Publishing (Optional)
-
-After the first publish, you can enable token-free publishing via OIDC:
-
-1. Go to [npmjs.com](https://www.npmjs.com) → Your Package → Settings → Publishing Access
-2. Click "Add Trusted Publisher"
-3. Configure:
-   - **Owner:** Your GitHub username/org
-   - **Repository:** Your repo name
-   - **Workflow file:** `publish.yml`
-4. Save changes
-5. Optionally remove the `NPM_TOKEN` secret from GitHub
-
-Now future releases will publish automatically without any tokens!
-
-## NPM Token Setup
-
-### Why Granular Tokens?
-
-As of December 2024, npm has revoked all classic tokens. You must use **granular access tokens** for CI/CD publishing.
-
-### Token Requirements
-
-| Setting | Value | Why |
-|---------|-------|-----|
-| Type | Granular Access Token | Classic tokens no longer work |
-| Packages | All packages (for new) or specific | Allows publishing |
-| Permissions | Read and write | Required to publish |
-| **Bypass 2FA** | **Checked** | **Required for CI/CD** |
-
-### Common Errors
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| "Access token expired or revoked" | Token doesn't have "Bypass 2FA" | Create new token with 2FA bypass |
-| "E404 Not Found" | Token doesn't have publish permissions | Check token has read/write access |
-| "E403 Forbidden" | Package scope mismatch | Ensure token covers your package scope |
-
-## What's Included
-
-### CI/CD Workflows
-
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `pr-quality.yml` | PR | Lint, Typecheck, Test with coverage |
-| `publish.yml` | Push to main | Auto-publish via Changesets |
-| `autogenerate-changeset.yml` | PR | Auto-generate changeset if missing |
-| `commitlint.yml` | PR | Enforce conventional commits |
-| `pr-title.yml` | PR | Validate PR title format |
-| `security.yml` | Push/Schedule | CodeQL + Trivy scanning |
-| `dependency-review.yml` | PR | Supply chain security |
-| `dependabot-auto-merge.yml` | Dependabot PR | Auto-merge patch updates |
-
-### GitHub Apps
-
-| App | Purpose |
-|-----|---------|
-| [Changeset Bot](https://github.com/apps/changeset-bot) | PR comments with changeset status |
-
-### Scripts
-
-```bash
-# Development
-bun dev              # Watch mode
-bun run build        # Build for production
-bun run clean        # Remove dist/
-
-# Quality
-bun run check        # Biome lint + format (write)
-bun run lint         # Lint only
-bun run format       # Format only
-bun run typecheck    # TypeScript type check
-bun run validate     # Full quality check (lint + types + build + test)
-
-# Testing
-bun test             # Run tests
-bun test --watch     # Watch mode
-bun run coverage     # With coverage report
-
-# Publishing
-bun run version:gen  # Create changeset interactively
-bun run release      # Publish to npm (CI handles this)
-```
-
-## Project Structure
-
-```
-├── .github/
-│   ├── workflows/        # CI/CD workflows
-│   ├── actions/          # Reusable composite actions
-│   └── scripts/          # CI helper scripts
-├── .husky/               # Git hooks
-├── .changeset/           # Changeset config
-├── src/
-│   └── index.ts          # Main entry point
-├── tests/
-│   └── index.test.ts     # Example test
-├── biome.json            # Biome config
-├── tsconfig.json         # TypeScript config
-├── bunup.config.ts       # Build config
-└── package.json
+bunx @side-quest/last-30-days "your topic"
 ```
 
 ## Configuration
 
-### Biome
-
-Configured in `biome.json`:
-- Tab indentation
-- 80 character line width
-- Single quotes
-- Organize imports on save
-
-### TypeScript
-
-- Strict mode enabled
-- ESM output
-- Source maps and declarations
-
-### Changesets
-
-- GitHub changelog format
-- Public npm access
-- Provenance enabled
-
-## Branch Protection
-
-The setup script automatically configures branch protection for `main`:
-
-- Require pull request before merging
-- Require status checks to pass ("All checks passed")
-- Require linear history
-- No force pushes
-- No deletions
-
-If you need to manually configure it:
-
-1. Go to Settings → Branches → Add rule
-2. Branch name pattern: `main`
-3. Enable the settings above
-
-## Troubleshooting
-
-### Setup script hangs
-
-If running in a non-TTY environment (like some CI systems), use CLI flags:
+API keys are loaded from environment variables or `~/.config/last-30-days/.env`:
 
 ```bash
-bun run setup -- --name "my-lib" --description "desc" --author "name" --yes
+OPENAI_API_KEY=sk-...   # Required for Reddit search (via OpenAI Responses API)
+XAI_API_KEY=xai-...     # Required for X search (via xAI Responses API)
 ```
 
-### CI can't create PRs
-
-The setup script enables this automatically. If you need to do it manually:
+## CLI Usage
 
 ```bash
-gh api repos/OWNER/REPO/actions/permissions/workflow \
-  --method PUT \
-  -f default_workflow_permissions=write \
-  -F can_approve_pull_request_reviews=true
+# Basic search
+last-30-days "Claude Code"
+
+# Deep search with JSON output
+last-30-days "React Server Components" --deep --emit=json
+
+# News-optimized query with YouTube
+last-30-days "GPT-5 release" --query-type=news --include-youtube
+
+# Two-phase search (broad discovery + entity drill-down)
+last-30-days "Rust async" --strategy=two-phase
+
+# Quick search, web included
+last-30-days "Bun 1.2" --quick --include-web
 ```
 
-### Version PR checks don't run
+### Options
 
-Bot-created PRs don't trigger workflows. Push an empty commit:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--emit=MODE` | `compact` | Output: compact, json, md, context, path |
+| `--sources=MODE` | `auto` | Source: auto, reddit, x, both |
+| `--days=N` | `30` | Lookback window (1-365) |
+| `--quick` | - | Faster with fewer results |
+| `--deep` | - | Comprehensive with more results |
+| `--include-web` | - | Include web search |
+| `--include-youtube` | - | Include YouTube (requires yt-dlp) |
+| `--strategy=MODE` | `single` | Search: single, two-phase |
+| `--phase2-budget=N` | `5` | Max supplemental queries per source |
+| `--query-type=TYPE` | `auto` | Intent: auto, prompting, recommendations, news, general |
+| `--telemetry=MODE` | `quiet` | Telemetry: quiet, verbose, file |
+| `--refresh` | - | Bypass cache reads |
+| `--no-cache` | - | Disable cache entirely |
+| `--outdir=PATH` | - | Write output files to PATH |
+| `--mock` | - | Use fixture data |
+| `--debug` | - | Verbose logging |
+
+### Watchlist
+
+Monitor topics over time with persistent tracking:
 
 ```bash
-git fetch origin
-git checkout changeset-release/main
-git commit --allow-empty -m "chore: trigger CI"
-git push
+# Add a topic to watch
+last-30-days watch add "AI agents" --every=weekly
+
+# List watched topics
+last-30-days watch list
+
+# View run history
+last-30-days watch history "AI agents" --limit=5
+
+# Remove a topic
+last-30-days watch remove "AI agents"
 ```
 
-### npm publish fails with 404
+### Briefings
 
-1. Ensure your npm token has "Bypass 2FA" checked
-2. Ensure token has "Read and write" permissions
-3. Ensure token covers "All packages" (for new packages)
+Generate briefings from watchlist run history:
+
+```bash
+# Daily briefing (compares last 2 runs)
+last-30-days briefing "AI agents"
+
+# Weekly briefing (compares last 8 runs)
+last-30-days briefing "AI agents" --period=weekly
+```
+
+## Architecture
+
+```
+CLI (Editor-in-Chief)
+  |
+  |-- Two-Phase Retrieval
+  |     |-- Phase 1: Parallel broad search across all sources
+  |     |-- Entity Extraction: @handles, r/subreddits, #hashtags, terms
+  |     |-- Phase 2: Entity-driven supplemental search
+  |
+  |-- Sources (Reporters)
+  |     |-- Reddit (via OpenAI Responses API)
+  |     |-- X/Twitter (via xAI Responses API)
+  |     |-- YouTube (via yt-dlp, opt-in)
+  |     |-- Web Search (delegated to Claude)
+  |
+  |-- Scoring (Copy Desk)
+  |     |-- Engagement-weighted scoring per source
+  |     |-- Trend scoring (momentum + source diversity)
+  |     |-- Intent-aware weight adjustment
+  |     |-- N-gram Jaccard deduplication
+  |
+  |-- Persistence
+  |     |-- SQLite watchlist (bun:sqlite)
+  |     |-- Delta detection between runs
+  |     |-- Briefing generation
+  |
+  |-- Observability
+        |-- Structured telemetry (l30d.run.completed.v1)
+        |-- Per-phase latency tracking
+        |-- Cache hit/miss metrics
+```
+
+## Development
+
+```bash
+bun install          # Install dependencies
+bun run dev          # Watch mode
+bun run build        # Build
+bun run validate     # Full pipeline: lint + typecheck + build + test
+bun run eval         # Benchmark harness
+bun run eval:pr      # Regression check against baseline
+```
 
 ## License
 
 MIT
-
----
-
-Built with [bun-typescript-starter](https://github.com/nathanvale/bun-typescript-starter)

--- a/specs/hybrid-retrieval-engine.md
+++ b/specs/hybrid-retrieval-engine.md
@@ -753,6 +753,23 @@ Governance rules:
 3. The sample fixture must remain valid against the runtime validator and formula locks.
 4. `src/lib/telemetry-contract.ts` is the TypeScript source-of-truth for implementation.
 
+## Completion Status
+
+| PR | Title | Status |
+|----|-------|--------|
+| PR-001 | Eval Harness + Oracle Baseline | Completed |
+| PR-002 | Retrieval Contracts | Completed |
+| PR-003 | Entity Extraction Module | Completed |
+| PR-004 | Two-Phase Supplemental Retrieval | Completed |
+| PR-005 | Cache/Retry Hardening for Phase 2 | Completed |
+| PR-006 | YouTube Source Adapter | Completed |
+| PR-007 | Trend-Aware Scoring Model | Completed |
+| PR-008 | Intent Classification + Query Policy | Completed |
+| PR-009 | Watchlist Persistence | Completed |
+| PR-010 | Briefing + Delta Intelligence | Completed |
+| PR-011 | Observability + SLO Guardrails | Completed |
+| PR-012 | CI Release Gates + Docs | Completed |
+
 ## PR-002 Checkpoint (e384c7e)
 
 ### Completed


### PR DESCRIPTION
## Summary
Implements **PR-012 (CI Release Gates + Docs)** from the hybrid retrieval plan.

This PR wires eval benchmarking into PR quality checks and updates project docs to match the full hybrid retrieval feature set.

## Why
The rollout needs enforceable release guardrails and accurate operator-facing docs for new flags, workflows, and architecture.

## What Changed
- Updated `.github/workflows/pr-quality.yml`
  - Added `eval` job running `bun run eval:pr`
  - Included eval status in required gate aggregation
  - Added eval result visibility in the PR summary output
- Updated `README.md`
  - Added/updated CLI flags and examples for:
    - `--strategy`
    - `--phase2-budget`
    - `--include-youtube`
    - `--query-type`
    - `--telemetry`
  - Documented watchlist + briefing commands
  - Updated architecture and development/eval command sections
- Updated `specs/hybrid-retrieval-engine.md`
  - Added completion-state updates across PR-001 to PR-012
  - Refreshed implementation/validation sections to reflect delivered stack

## Behavior and Compatibility
- CI now enforces eval benchmark success in the PR quality pipeline.
- Documentation now reflects the implemented feature surface and workflow.

## Validation
- `bun run validate`
- `bun run eval:pr`

## Risk
Low. Workflow/documentation changes only; no runtime logic changes in the app code path.
