### PR TITLE
fix(youtube): enforce lookback window and case-safe URL dedupe

### DIFF
--- a/src/adapters/youtube.ts
+++ b/src/adapters/youtube.ts
@@ -1,5 +1,51 @@
 import { parseYtDlpJsonLines } from '../lib/youtube.js'
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/** Clamp lookback days to a safe positive integer window. */
+function clampLookbackDays(days: number): number {
+	if (!Number.isFinite(days)) return 30
+	const normalized = Math.floor(days)
+	if (normalized < 1) return 1
+	if (normalized > 365) return 365
+	return normalized
+}
+
+/** Format a UTC date as YYYYMMDD for yt-dlp date filters. */
+function formatYtDate(date: Date): string {
+	const year = date.getUTCFullYear()
+	const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+	const day = String(date.getUTCDate()).padStart(2, '0')
+	return `${year}${month}${day}`
+}
+
+/**
+ * Build yt-dlp args for time-windowed YouTube search.
+ *
+ * Uses ytsearchdate to bias recent uploads and --dateafter to enforce
+ * the requested lookback window.
+ */
+export function buildYouTubeSearchArgs(
+	topic: string,
+	days: number,
+	depth: string,
+	now: Date = new Date(),
+): string[] {
+	const maxResults = depth === 'quick' ? 5 : depth === 'deep' ? 20 : 10
+	const lookbackDays = clampLookbackDays(days)
+	const dateAfter = new Date(now.getTime() - lookbackDays * MS_PER_DAY)
+	const query = `ytsearchdate${maxResults}:${topic}`
+
+	return [
+		'yt-dlp',
+		'--flat-playlist',
+		'--dump-json',
+		'--dateafter',
+		formatYtDate(dateAfter),
+		query,
+	]
+}
+
 /** Check if yt-dlp is available in PATH. */
 export function isYtDlpAvailable(): boolean {
 	try {
@@ -15,16 +61,11 @@ export function isYtDlpAvailable(): boolean {
 /** Search YouTube for videos matching a topic using yt-dlp. */
 export async function searchYouTube(
 	topic: string,
-	_days: number,
+	days: number,
 	depth: string,
 ): Promise<Record<string, unknown>[]> {
-	const maxResults = depth === 'quick' ? 5 : depth === 'deep' ? 20 : 10
-	const query = `ytsearch${maxResults}:${topic}`
-
-	const result = Bun.spawnSync(
-		['yt-dlp', '--flat-playlist', '--dump-json', query],
-		{ timeout: 60_000 },
-	)
+	const args = buildYouTubeSearchArgs(topic, days, depth)
+	const result = Bun.spawnSync(args, { timeout: 60_000 })
 
 	if (result.exitCode !== 0) {
 		const stderr = result.stderr.toString().trim()

--- a/src/lib/dedupe.ts
+++ b/src/lib/dedupe.ts
@@ -21,6 +21,65 @@ function trimTrailingSlashes(value: string): string {
 	return value.slice(0, end)
 }
 
+/**
+ * Extract canonical YouTube video ID from common URL formats.
+ * ID case is preserved because YouTube IDs are case-sensitive.
+ */
+function extractYouTubeVideoId(url: string): string | null {
+	const trimmed = url.trim()
+	if (!trimmed) return null
+
+	try {
+		const parsed = new URL(trimmed)
+		const host = parsed.hostname.toLowerCase()
+		const pathParts = parsed.pathname.split('/').filter(Boolean)
+
+		if (host === 'youtu.be' || host.endsWith('.youtu.be')) {
+			return pathParts[0] ?? null
+		}
+
+		if (
+			host === 'youtube.com' ||
+			host === 'www.youtube.com' ||
+			host.endsWith('.youtube.com')
+		) {
+			const watchId = parsed.searchParams.get('v')
+			if (watchId) return watchId
+
+			if (pathParts.length >= 2) {
+				const [prefix, id] = pathParts
+				if (
+					(prefix === 'shorts' || prefix === 'embed' || prefix === 'live') &&
+					id
+				) {
+					return id
+				}
+			}
+		}
+	} catch {
+		// Ignore malformed URLs and fall back to non-ID keying.
+	}
+
+	return null
+}
+
+/** Build a stable dedupe key for YouTube items. */
+function youtubeDedupeKey(item: YouTubeItem): string {
+	const videoId = extractYouTubeVideoId(item.url) ?? item.id.trim()
+	if (videoId) return `video:${videoId}`
+
+	// Fallback: keep path/query case intact, but normalize host case.
+	try {
+		const parsed = new URL(item.url.trim())
+		const host = parsed.hostname.toLowerCase()
+		const path = trimTrailingSlashes(parsed.pathname)
+		const query = parsed.search ? parsed.search : ''
+		return `${host}${path}${query}`
+	} catch {
+		return trimTrailingSlashes(item.url.trim())
+	}
+}
+
 /** Get character n-grams from text. */
 export function getNgrams(text: string, n = 3): Set<string> {
 	const normalized = normalizeText(text)
@@ -110,13 +169,13 @@ export function dedupeX(items: XItem[], threshold = 0.7): XItem[] {
 	return dedupeItems(items, threshold)
 }
 
-/** Dedupe YouTube items by URL (titles are unreliable). */
+/** Dedupe YouTube items by canonical video ID (titles are unreliable). */
 export function dedupeYouTube(items: YouTubeItem[]): YouTubeItem[] {
 	const seenUrls = new Set<string>()
 	const result: YouTubeItem[] = []
 
 	for (const item of items) {
-		const urlKey = trimTrailingSlashes(item.url.toLowerCase())
+		const urlKey = youtubeDedupeKey(item)
 		if (!seenUrls.has(urlKey)) {
 			seenUrls.add(urlKey)
 			result.push(item)

--- a/tests/youtube-adapter.test.ts
+++ b/tests/youtube-adapter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildYouTubeSearchArgs } from '../src/adapters/youtube'
+
+describe('buildYouTubeSearchArgs', () => {
+	const now = new Date('2026-02-19T12:00:00.000Z')
+
+	test('uses quick depth with recent-date search and dateafter filter', () => {
+		const args = buildYouTubeSearchArgs('claude code', 30, 'quick', now)
+		expect(args).toEqual([
+			'yt-dlp',
+			'--flat-playlist',
+			'--dump-json',
+			'--dateafter',
+			'20260120',
+			'ytsearchdate5:claude code',
+		])
+	})
+
+	test('uses deep depth with 20 results', () => {
+		const args = buildYouTubeSearchArgs('bun typescript', 7, 'deep', now)
+		expect(args).toEqual([
+			'yt-dlp',
+			'--flat-playlist',
+			'--dump-json',
+			'--dateafter',
+			'20260212',
+			'ytsearchdate20:bun typescript',
+		])
+	})
+
+	test('defaults to 10 results for standard depth', () => {
+		const args = buildYouTubeSearchArgs('hello', 14, 'normal', now)
+		expect(args[5]).toBe('ytsearchdate10:hello')
+	})
+
+	test('clamps lookback window to 1..365 days', () => {
+		const minimum = buildYouTubeSearchArgs('topic', 0, 'normal', now)
+		const maximum = buildYouTubeSearchArgs('topic', 999, 'normal', now)
+		expect(minimum[4]).toBe('20260218')
+		expect(maximum[4]).toBe('20250219')
+	})
+})

--- a/tests/youtube.test.ts
+++ b/tests/youtube.test.ts
@@ -289,7 +289,7 @@ describe('dedupeYouTube', () => {
 		expect(dedupeYouTube(items)).toHaveLength(2)
 	})
 
-	test('URL comparison is case-insensitive', () => {
+	test('URL host comparison is case-insensitive for same video ID', () => {
 		const items: YouTubeItem[] = [
 			defaultYouTubeItem({
 				id: 'v1',
@@ -300,12 +300,31 @@ describe('dedupeYouTube', () => {
 			defaultYouTubeItem({
 				id: 'v2',
 				title: 'Dup',
-				url: 'https://www.youtube.com/watch?v=abc',
+				url: 'https://www.youtube.com/watch?v=ABC',
 				channel: 'Ch',
 			}),
 		]
 
 		expect(dedupeYouTube(items)).toHaveLength(1)
+	})
+
+	test('keeps URLs whose video IDs differ only by case', () => {
+		const items: YouTubeItem[] = [
+			defaultYouTubeItem({
+				id: 'v1',
+				title: 'Uppercase ID',
+				url: 'https://www.youtube.com/watch?v=ABC',
+				channel: 'Ch',
+			}),
+			defaultYouTubeItem({
+				id: 'v2',
+				title: 'Lowercase ID',
+				url: 'https://www.youtube.com/watch?v=abc',
+				channel: 'Ch',
+			}),
+		]
+
+		expect(dedupeYouTube(items)).toHaveLength(2)
 	})
 
 	test('handles empty array', () => {


### PR DESCRIPTION
## Summary
- make YouTube search date-aware by using `ytsearchdate` plus `--dateafter` derived from the requested `days` window
- preserve case-sensitive YouTube video IDs during dedupe by keying on canonical video ID (with URL fallback), instead of lowercasing full URLs
- add regression tests for adapter arg construction and ID-case dedupe behavior

## Validation
- bun test (292 passed)
- tsc --noEmit (0 errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YouTube search now supports time-windowed filtering for more precise results across different date ranges

* **Bug Fixes**
  * Improved YouTube video duplicate detection to accurately identify the same video across different URL formats, reducing duplicate entries in search results
  * Enhanced YouTube URL parsing for better recognition of different link formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->