### PR TITLE
fix(cli): validate --phase2-budget when flag has no value or negative arg

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,7 +200,9 @@ function parseArgs(args: string[]) {
 			phase2Budget = Number(arg.slice('--phase2-budget='.length))
 		} else if (arg === '--phase2-budget') {
 			const value = args[i + 1]
-			if (value && !value.startsWith('-')) {
+			if (!value || value.startsWith('-')) {
+				phase2Budget = Number.NaN
+			} else {
 				phase2Budget = Number(value)
 				i += 1
 			}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1036,6 +1036,11 @@ describe('cli', () => {
 		expect(result.exitCode).toBe(0)
 	})
 
+	test('--phase2-budget 3 is accepted', () => {
+		const result = runCli(['test topic', '--mock', '--emit=json', '--phase2-budget', '3'])
+		expect(result.exitCode).toBe(0)
+	})
+
 	test('--strategy=invalid exits with error', () => {
 		const result = runCli(['test topic', '--mock', '--strategy=invalid'])
 		expect(result.exitCode).toBe(1)
@@ -1052,6 +1057,20 @@ describe('cli', () => {
 
 	test('--phase2-budget=abc exits with error', () => {
 		const result = runCli(['test topic', '--mock', '--phase2-budget=abc'])
+		expect(result.exitCode).toBe(1)
+		const stderr = new TextDecoder().decode(result.stderr)
+		expect(stderr).toContain('--phase2-budget must be an integer')
+	})
+
+	test('--phase2-budget -1 exits with error', () => {
+		const result = runCli(['test topic', '--mock', '--phase2-budget', '-1'])
+		expect(result.exitCode).toBe(1)
+		const stderr = new TextDecoder().decode(result.stderr)
+		expect(stderr).toContain('--phase2-budget must be an integer')
+	})
+
+	test('--phase2-budget without value exits with error', () => {
+		const result = runCli(['test topic', '--mock', '--phase2-budget'])
 		expect(result.exitCode).toBe(1)
 		const stderr = new TextDecoder().decode(result.stderr)
 		expect(stderr).toContain('--phase2-budget must be an integer')


### PR DESCRIPTION
## Summary

- Fix `--phase2-budget` parser to correctly handle missing value or negative argument (e.g. `--phase2-budget -1`)
- Previously the condition silently ignored these cases; now assigns `NaN` so the existing validation rejects with the expected error message

## Test plan

- [ ] `--phase2-budget 3` accepted with exit code 0
- [ ] `--phase2-budget -1` exits with code 1 and `--phase2-budget must be an integer` in stderr
- [ ] `--phase2-budget` (no value) exits with code 1 and `--phase2-budget must be an integer` in stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for the --phase2-budget parameter to properly reject missing values and invalid input formats

* **Tests**
  * Added comprehensive test coverage for --phase2-budget argument handling, validating both correct formats and error cases with appropriate error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->