### PR TITLE
feat(diagnostics): surface rate-limit diagnostics in report and compact output

### DIFF
--- a/.changeset/rate-limit-diagnostics.md
+++ b/.changeset/rate-limit-diagnostics.md
@@ -1,0 +1,7 @@
+---
+"@side-quest/word-on-the-street": minor
+---
+
+Surface rate-limit diagnostics in Report schema and compact output
+
+When a 429 rate limit is encountered, the Report now includes structured per-source diagnostic fields: `*_rate_limit_type` (transient vs quota), `*_rate_limit_error_code`, `*_rate_limit_reset_ms`, `*_rate_limit_retry_after_ms`, `*_rate_limit_retries_attempted`, `*_used_stale_cache`, and `*_cache_age_hours`. Compact output renders a structured diagnostics block instead of a flat error string. Happy-path output is unchanged - fields are omitted when no rate limit occurred.

--- a/docs/plans/2026-02-25-feat-wots-logtape-observability-plan.md
+++ b/docs/plans/2026-02-25-feat-wots-logtape-observability-plan.md
@@ -1,0 +1,677 @@
+---
+title: "feat: Add LogTape Structured Observability to wots CLI"
+type: feat
+status: active
+date: 2026-02-25
+origin: docs/logtape-cli-observability-spec.md
+---
+
+# feat: Add LogTape Structured Observability to wots CLI
+
+## Overview
+
+Add structured logging and observability to `@side-quest/word-on-the-street` using LogTape -- replacing ad-hoc `[debug]` stderr writes with a unified, hierarchical, context-aware logging system that serves three consumers simultaneously: humans (interactive terminal), developers (debugging failures), and AI agents (machine-readable diagnostics).
+
+## Problem Statement
+
+The wots CLI has **four distinct observability gaps** that compound into a poor debugging experience:
+
+1. **Silent cache layer**: Cache hits, misses, stale fallbacks, and lock contention produce zero diagnostic output. When a user gets stale data, there's no way to know why without reading source code.
+
+2. **Swallowed errors**: 10+ `catch` blocks in `cache.ts`, `render.ts`, and the Reddit task retry logic silently discard errors. Transient API failures, cache write failures, and render errors vanish without trace.
+
+3. **Two disconnected debug systems**: The `--debug` flag in `cli.ts` writes `[debug]` to stderr at runtime. The `DEBUG` constant in `http.ts` reads `WOTS_DEBUG` at import time. The flag sets the env var after import, creating a race condition where `--debug` doesn't enable HTTP debug logging.
+
+4. **No structured diagnostics for AI agents**: Beat Reporter sub-agents run `wots --json --quiet` and get a JSON envelope on stdout. When the envelope contains `"status": "error"`, the agent has no diagnostic context -- just an error message string. There's no structured trace of what went wrong.
+
+**Impact**: Debugging a "why did my search return stale data?" question currently requires: adding `console.error()` calls to source, rebuilding, re-running, reading terminal output, then removing the debug code. With LogTape, it's `wots "topic" --debug` and reading structured output.
+
+## Proposed Solution
+
+Add `@logtape/logtape` (zero dependencies, 5.3 KB min+gz) as the second runtime dependency. Wire it into the CLI entry point with a synchronous configuration module that maps existing flags (`--debug`, `--quiet`) to LogTape log levels. **v1 ships Phase 1 only**: unified logging, race condition fix, ProgressDisplay mode refactor, minimal cache warnings with remediation context, and a robust shutdown path via try/finally. `--verbose` is deferred to Phase 2 (no distinct info-level content in Phase 1). Async context propagation (`withContext()`) and fingers-crossed auto-flush are designed but deferred to Phases 2 and 3 -- evaluate need after real usage.
+
+## Technical Approach
+
+### Architecture
+
+```
+Phase 1 (v1):
+┌─────────────────────────────────────────────────────┐
+│  cli.ts main()                                      │
+│                                                     │
+│  1. parseCliArgs()          (before LogTape)        │
+│  2. setupLogging(flags)     (configures LogTape)    │
+│  3. ... search orchestration ...                    │
+│  4. shutdownLogging()       (before process.exit)   │
+│                                                     │
+│  Sink: consoleSink(stderr)  -- direct, no buffering │
+└─────────────────────────────────────────────────────┘
+
+Phase 2 adds: withContext() around Promise.all() branches
+Phase 3 adds: fingersCrossed() wrapper on the sink for default mode
+Phase 4 adds: fileSink, otelSink (as-needed)
+```
+
+**Category hierarchy**:
+```
+wots                          # Root -- catch-all
+├── wots.cli                  # Arg parsing, flag resolution, entry/exit
+├── wots.cache                # Cache hits, misses, stale fallbacks, locks
+├── wots.http                 # HTTP retries, rate limits, response status
+├── wots.search               # Search orchestration
+│   ├── wots.search.reddit    # OpenAI Responses API calls
+│   ├── wots.search.x         # xAI API calls
+│   └── wots.search.youtube   # yt-dlp invocations
+├── wots.enrich               # Reddit enrichment via JSON API (Phase 2)
+└── wots.score                # Top-N scoring summary only (Phase 2)
+
+Future categories (add when logging is needed):
+  wots.render                 # Output formatting decisions
+  wots.watchlist              # SQLite ops, briefing generation
+```
+
+Note: `wots.search.web` is intentionally excluded. Web search is performed by the Beat Reporter agent (via WebSearch/WebFetch), not by the wots CLI. The CLI only generates `web_search_instructions` in the JSON envelope.
+
+### Implementation Phases
+
+> **Scope decision (from Codex review):** Only Phase 1 ships as v1. Phase 2 and Phase 3
+> are deferred -- they add value but are not required for the core observability win
+> (unified logging, race condition fix, structured debug output). Evaluate need after
+> Phase 1 ships and real usage surfaces gaps.
+
+#### Phase 1: Foundation (v1 -- ships now)
+
+**Goal**: Replace ad-hoc debug writes with LogTape. Add minimal cache warnings with remediation context. Zero user-visible behavior change in default mode; structured debug output when `--debug` is active. `--verbose` deferred to Phase 2.
+
+**Tasks**:
+
+- [ ] Add `@logtape/logtape` as runtime dependency in `package.json`
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/package.json`
+
+- [ ] Create `src/lib/logging.ts` -- LogTape configuration module
+  - `setupLogging(opts: LoggingOptions): void` (synchronous -- `configure()` is sync in Phase 1; no async sinks or context)
+  - Flag-to-level mapping: none=warning, --debug=debug, --quiet=error
+  - Formatter selection: ANSI color when interactive TTY, JSON Lines when --json or stderr not TTY
+  - Do NOT create `AsyncLocalStorage` yet -- defer to Phase 2 when `withContext()` is wired up
+  - Export a `shutdownLogging(): Promise<void>` function that calls `await dispose()` (single point of teardown)
+  - `shutdownLogging()` must be idempotent -- safe to call before `setupLogging()`, after failed `setupLogging()`, or multiple times
+  - Accept an optional `disposeFn` parameter for testing: `shutdownLogging(disposeFn?: () => Promise<void>)` -- defaults to LogTape's `dispose()`, but tests can inject a mock to verify timeout behavior
+
+- [ ] Wire `setupLogging()` into `cli.ts` main() after `parseCliArgs()`, before any search logic
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/cli.ts` ~line 710 (after flag resolution)
+
+- [ ] Replace all `[debug]` stderr writes in `cli.ts` with logger calls
+  - Line 731-732: `[debug] strategy=... phase2Budget=...` -> `logger.debug("Strategy resolved: {strategy}, budget={budget}", ...)`
+  - Line 804-808: `[debug] query-type=...` -> `logger.debug("Query type resolved: {queryType}", ...)`
+  - Lines 1160-1167: `[debug] counts reddit raw=...` -> `logger.debug("Result counts: {reddit} reddit, {x} X, {youtube} YouTube", ...)`
+
+- [ ] Replace `http.ts` DEBUG constant and log() helper with LogTape
+  - Remove module-level `DEBUG` constant (lines 10-12) and `log()` function (lines 14-17)
+  - Replace with `const logger = getLogger(["wots", "http"])`
+  - Replace `log(msg)` calls with `logger.debug(msg)` -- the level check is now dynamic, fixing the race condition
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/http.ts`
+
+- [ ] Remove `process.env.WOTS_DEBUG = '1'` assignment in `cli.ts` (line 730)
+  - No longer needed -- LogTape's level configuration handles this
+  - Note: `tests/smoke-test-prompt.md` references `WOTS_DEBUG=1` -- update that doc to reference `--debug` instead
+  - The `export const DEBUG` in `http.ts` is not imported anywhere -- safe to remove entirely
+
+- [ ] **`--verbose` deferred to Phase 2** (DX review finding: no distinct Phase 1 info-level content exists yet; shipping `--verbose` now risks being "different noise mode" rather than useful signal. Phase 2 adds lifecycle events and search progress that justify `--verbose`.)
+
+- [ ] Add `mode` property to `ProgressDisplay` to prevent stderr interleaving with LogTape
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/ui.ts`
+  - `"animated"` (default) -- spinners, current behavior
+  - `"static"` (reserved for Phase 2 `--verbose`) -- phase names without animation, no spinner control chars
+  - `"off"` (`--debug`, `--quiet`) -- suppressed entirely
+
+  **Call-site inventory** (verified via grep -- only 1 construction site):
+  - `cli.ts` line 853: `new ProgressDisplay(args.topic, true, outputArgs.quiet)`
+
+  **Compatibility strategy** (addresses Architect review -- ProgressDisplay is public API via `src/index.ts`):
+
+  Add a constructor overload that preserves the existing positional signature:
+  ```typescript
+  // Overload 1: legacy positional args (preserves public API)
+  constructor(topic: string, showBanner?: boolean, quiet?: boolean);
+  // Overload 2: new options object (internal use)
+  constructor(opts: {
+    topic: string;
+    showBanner?: boolean;
+    mode?: 'animated' | 'static' | 'off';
+  });
+  // Implementation
+  constructor(
+    topicOrOpts: string | { topic: string; showBanner?: boolean; mode?: 'animated' | 'static' | 'off' },
+    showBanner?: boolean,
+    quiet?: boolean,
+  ) {
+    if (typeof topicOrOpts === 'string') {
+      // Legacy path: quiet maps to mode: 'off'
+      this.topic = topicOrOpts;
+      this.showBanner = showBanner ?? true;
+      this.mode = quiet ? 'off' : 'animated';
+    } else {
+      this.topic = topicOrOpts.topic;
+      this.showBanner = topicOrOpts.showBanner ?? true;
+      this.mode = topicOrOpts.mode ?? 'animated';
+    }
+  }
+  ```
+
+  This means library consumers calling `new ProgressDisplay("topic", true, false)` continue to work unchanged. The internal call site in `cli.ts` switches to the options form:
+  ```typescript
+  const progressMode = args.debug || outputArgs.quiet ? 'off' : 'animated';
+  const progress = new ProgressDisplay({
+    topic: args.topic,
+    mode: progressMode,
+  });
+  ```
+
+- [ ] Add minimal cache warning logging with remediation context (pulled forward from Phase 2)
+  - Add `const logger = getLogger(["wots", "cache"])` to `cache.ts`
+  - Each warning must include: (1) what happened, (2) what the CLI did about it, (3) whether user action is needed. This prevents raw warnings from alarming users.
+  - `warn` on cache write failure (`cache.ts` lines 231-237):
+    `logger.warn("Cache write failed for {key}: {error}. Using fresh data. No action needed unless repeated.", { key, error: e.message })`
+  - `warn` on corrupted cache read (`cache.ts` line 159):
+    `logger.warn("Cache file corrupted for {key}. Ignored, fetching fresh data. Run with --no-cache to force.", { key })`
+  - `warn` on stale lock detection (`cache.ts` line 305):
+    `logger.warn("Stale lock detected for {key} (age: {age}ms). Overriding. Likely a crashed previous run.", { key, age })`
+  - These are the highest-value cache diagnostics; remaining debug-level cache logging defers to Phase 2
+
+- [ ] **Error emission ownership rule** (addresses Architect review on duplicate stderr writes):
+  `writeError()` in `output.ts` is the sole owner of user-facing terminal errors. LogTape `error`-level messages are for diagnostic traces only (e.g., "all retries exhausted for reddit API" with structured context). The rule:
+  - `writeError()` -- user-facing error messages (validation failures, fatal errors). Writes to stderr (and stdout in JSON mode for envelope errors).
+  - `logger.error()` -- diagnostic context for the same failure (retry count, response codes, timing). Never duplicates the user-facing message.
+  - In Phase 1, `logger.error()` is not used at all (no error-level diagnostic logging). All error-level logging defers to Phase 2's catch block migration.
+  - This avoids double-write: `writeError("Search failed")` on stderr + `logger.error("Search failed")` on stderr.
+
+- [ ] Wire shutdown into all termination paths (see Shutdown Design below)
+
+**Shutdown design** (addresses Architect review -- prefer try/finally over scattered process.exit()):
+
+Restructure `main()` to use try/finally so shutdown is guaranteed regardless of exit path:
+
+```typescript
+// cli.ts -- restructured termination
+async function main(): Promise<number> {
+  const args = parseCliArgs();
+  setupLogging({ debug: args.debug, quiet: args.quiet, json: args.json });
+  try {
+    // ... search orchestration ...
+    return 0;
+  } catch (e) {
+    writeError(/* ... */);
+    return exitCodeFromError(e);
+  } finally {
+    await shutdownLogging();
+  }
+}
+
+// Entry point
+process.on('SIGINT', async () => {
+  await shutdownLogging();
+  process.exit(EXIT_INTERRUPTED);
+});
+
+main().then((code) => process.exit(code));
+```
+
+This replaces the current `.then()/.catch()` chain with a single try/finally that guarantees `shutdownLogging()` runs on normal exit, error exit, and (best-effort) SIGINT. SIGINT remains a separate handler because `finally` doesn't run on signal-induced exits.
+
+**Why this is safe for Phase 1**: Without fingers-crossed (Phase 3), `dispose()` only flushes the synchronous console sink -- effectively a no-op. The shutdown path is established now so Phase 3 can add buffered sinks without changing termination logic.
+
+**`shutdownLogging()` implementation** -- idempotent with timeout guard and DI hook for testing:
+```typescript
+let configured = false;
+
+export function setupLogging(opts: LoggingOptions): void {
+  configure({ /* ... */ });
+  configured = true;
+}
+
+export async function shutdownLogging(
+  disposeFn: () => Promise<void> = dispose,
+): Promise<void> {
+  if (!configured) return; // no-op if setup never ran or already shut down
+  configured = false;
+  const timeout = new Promise<void>((resolve) => setTimeout(resolve, 500));
+  await Promise.race([disposeFn(), timeout]);
+}
+```
+
+The `disposeFn` parameter (defaults to LogTape's `dispose()`) enables tests to inject a mock that verifies timeout behavior, slow disposal, and error handling -- without monkeypatching global module state.
+
+**Success criteria**:
+- `wots "topic"` (default mode) produces identical stdout/stderr output as before (no regressions)
+- `wots "topic" --debug` produces structured LogTape output instead of `[debug]` prefix lines. ProgressDisplay spinners are suppressed (intentional behavior change -- debug users want log data, not animation).
+- No regressions in default mode; targeted test updates permitted for changed `[debug]` -> LogTape format
+- `--debug` now enables HTTP debug logging (race condition fixed)
+- `shutdownLogging()` is called on every exit path via try/finally (normal, error) and SIGINT handler
+- `shutdownLogging()` is idempotent -- safe before setup, after failed setup, or when called twice
+- Cache write failures, corrupted cache reads, and stale locks surface as warnings with remediation context
+- `writeError()` remains sole owner of user-facing error messages; logger never emits duplicate error text
+- Log invariant tests pass: no logs in stdout, no envelope fragments in stderr, --quiet stderr empty on success
+
+**Estimated effort**: ~3 hours (increased from 2h to account for ProgressDisplay refactor and shutdown wiring)
+
+**Concrete output fixtures** (addresses DX review -- each mode must have a golden example):
+
+```
+# Default mode (no flags) -- successful run, cache healthy
+$ wots "Claude Code" --mock
+stdout: [normal compact output, unchanged]
+stderr: [ProgressDisplay spinners only, unchanged]
+
+# Default mode -- cache corruption during run
+$ wots "Claude Code" --mock
+stdout: [normal compact output, unchanged]
+stderr: ⠋ Researching Claude Code...
+        [warn] Cache file corrupted for reddit:claude-code. Ignored, fetching fresh data.
+        ⠙ Analyzing results...
+        [compact output]
+
+# --debug mode -- TTY
+$ wots "Claude Code" --debug --mock
+stdout: [normal compact output, unchanged]
+stderr: [debug] Strategy resolved: balanced, budget=30
+        [debug] Query type: recommendations
+        [debug] HTTP GET https://api.reddit.com/... 200 (142ms)
+        [debug] Cache miss: reddit:claude-code
+        [debug] HTTP GET https://api.x.ai/... 200 (89ms)
+        [debug] Cache hit: x:claude-code (age: 12m)
+        [debug] Result counts: 15 reddit, 10 X, 5 YouTube
+
+# --debug mode -- non-TTY (piped)
+$ wots "Claude Code" --debug --mock 2>debug.log
+stderr (JSON Lines):
+  {"ts":"...","level":"debug","cat":"wots.cli","msg":"Strategy resolved: balanced, budget=30"}
+  {"ts":"...","level":"debug","cat":"wots.http","msg":"GET https://api.reddit.com/... 200 (142ms)"}
+
+# --quiet mode
+$ wots "Claude Code" --quiet --mock
+stdout: [normal compact output, unchanged]
+stderr: [empty unless error-level event occurs]
+
+# --json mode
+$ wots "Claude Code" --json --mock
+stdout: {"status":"success","data":{...}}
+stderr: [empty in default mode; JSON Lines if --debug also active]
+```
+
+Note: These are approval fixtures, not snapshot tests. Implementation tests should use semantic assertions (regex for key fragments, JSON parse + field checks) rather than full-line matching to avoid formatter drift.
+
+**Test isolation strategy** (addresses Test Engineer review):
+
+1. **Non-TTY format risk** (tests use `Bun.spawnSync()` which is non-TTY):
+   - LogTape auto-detects non-TTY and switches to JSON Lines formatter on stderr
+   - Tests that assert stderr content must account for this. Strategy: in `setupLogging()`, respect a `WOTS_LOG_FORMAT=text` env var override that forces human-readable format regardless of TTY detection. Set this in test harness.
+   - This makes tests deterministic across TTY/non-TTY without disabling logging
+
+2. **Cache warning leakage in `--mock` tests**:
+   - `--mock` mode uses fixture data, not real cache. Cache warnings should never fire in mock mode.
+   - Add a guard: `if (opts.mock) return;` at the top of cache read/write functions, skipping cache entirely. This is the existing behavior -- verify it with an assertion.
+   - For tests that DO use real cache (non-mock integration tests), set `WOTS_CACHE_DIR` to a temp directory per test process. Add this env var to the cache module.
+
+3. **Explicit stdout/stderr invariant test**:
+   - Add a new test file: `tests/log-invariants.test.ts`
+   - Tests:
+     - `stdout contains only program output (no log messages)` -- for default, --debug, --quiet modes
+     - `stderr contains no JSON envelope fragments` -- for all modes
+     - `--quiet stderr is empty on success` -- no warnings, no progress, no logs
+   - These tests use `Bun.spawnSync()` with `--mock` and parse stdout/stderr separately
+
+4. **setupLogging() failure and idempotent shutdownLogging()**:
+   - Test: call `shutdownLogging()` before `setupLogging()` -- should no-op
+   - Test: call `setupLogging()` with invalid config, then `shutdownLogging()` -- should no-op (not throw)
+   - Test: call `shutdownLogging()` twice -- second call is no-op
+   - Test: inject a slow `disposeFn` (>500ms) -- verify `shutdownLogging()` returns within 600ms (timeout fires)
+   - All via the `disposeFn` DI parameter, no monkeypatching needed
+
+---
+
+#### Phase 2: Async Context, --verbose Flag, and Silent Module Logging (deferred -- evaluate after Phase 1)
+
+**Goal**: Add implicit context propagation to parallel search orchestration. Add `--verbose` flag with lifecycle events. Log remaining cache operations and silenced errors.
+
+**Trigger**: Ship Phase 1, use it for a week, then evaluate whether async context, lifecycle logging, and per-source log tagging are needed for real debugging sessions.
+
+**Tasks**:
+
+- [ ] Add `--verbose` flag to `parse-args.ts` (deferred from Phase 1 -- no distinct info-level content until lifecycle logging exists)
+  - Maps to LogTape `info` level -- shows search started/completed per source, enrichment progress
+  - ProgressDisplay mode: `static` (phase names without animation)
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/parse-args.ts`
+
+- [ ] Add `AsyncLocalStorage` to `setupLogging()` (deferred from Phase 1)
+  - `contextLocalStorage: new AsyncLocalStorage()` passed to LogTape's `configure()`
+
+- [ ] Wrap each `Promise.all()` branch in `cli.ts` with `withContext()`
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/cli.ts` ~lines 922-1000
+  - Context properties: `{ source: "reddit"|"x"|"youtube", topic }`
+  - Every log message inside the branch automatically carries these properties
+
+- [ ] Add remaining structured logging to `cache.ts` (beyond Phase 1 warnings)
+  - File: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/cache.ts`
+  - `debug` on cache hit (key, age, version)
+  - `debug` on cache miss (key)
+  - `debug` on cache expired (key, age, ttl)
+  - `warn` on stale cache fallback (key, staleAge, reason)
+  - `warn` on lock contention (key, waitTime)
+
+- [ ] Add structured logging to remaining silent catch blocks:
+
+  | Location | Current Behavior | New Log Level | Rationale |
+  |----------|-----------------|---------------|-----------|
+  | `cache.ts` line 172 (mtime read) | Silent swallow | `debug` | Benign -- file might not exist yet |
+  | `cache.ts` line 272 (lock release) | Silent swallow | `debug` | Benign -- lock file already gone |
+  | `cli.ts` ~line 329 (reddit retry) | Retry + fallback | `info` | Informational -- retry succeeded |
+  | `cli.ts` ~line 364 (reddit exhausted) | Error captured | `error` | All retries failed |
+  | `render.ts` (file write) | Silent swallow | `warn` | Output file failed but report still renders |
+
+- [ ] Add search lifecycle logging
+  - `info` on search started (per source, with topic)
+  - `info` on search completed (per source, item count, fromCache, duration)
+  - `warn` on rate limit (source, usedStaleCache, cacheAge)
+  - `error` on search failed (source, error message)
+
+- [ ] Add enrichment logging (`wots.enrich` category)
+  - `info` on enrichment started (item count)
+  - `debug` on per-item enrichment (url, cache hit/miss)
+  - `warn` on enrichment failure (url, error)
+
+- [ ] Add scoring summary logging (`wots.score` category)
+  - `debug` on scoring complete (top score, median, item count) -- NOT per-item
+
+- [ ] Add top-level run context
+  - `withContext({ topic, depth, sources, runId: crypto.randomUUID().slice(0, 8) }, ...)`
+  - Wraps the entire search orchestration so every log carries the run ID
+
+**Success criteria**:
+- `wots "topic" --debug` produces a complete structured trace of the search pipeline
+- Each parallel search branch is identifiable by `source` context property
+- Cache hit/miss/stale events are visible at debug level
+- Previously-silent errors surface at appropriate levels
+- AI agents can parse JSON Lines stderr to identify which source failed and why
+
+**Estimated effort**: ~3 hours
+
+---
+
+#### Phase 3: Fingers Crossed Sink (deferred -- evaluate after Phase 2)
+
+**Goal**: Auto-flush debug traces on error without requiring `--debug`. Users who run `wots "topic"` normally see no debug output -- but when something fails, they get the full diagnostic trace.
+
+**Trigger**: Phase 2 is complete and there are concrete failure cases where users needed `--debug` retroactively. Without evidence of this pain point, simple level-based logging from Phase 1 is sufficient.
+
+**Tasks**:
+
+- [ ] Modify `setupLogging()` to use `fingersCrossed()` wrapper
+  - **When active**: Default mode (no flags) only
+  - **When inactive**: `--verbose` (user wants immediate info output), `--debug` (already showing everything), `--quiet` (user wants silence)
+  - Logger level is `debug` when fingers-crossed is active (the sink handles suppression)
+  - When `--verbose` is active, logger level is `info` with direct console sink (no buffering)
+
+  ```typescript
+  // Pseudocode for the three-mode setup
+  const useFingersCrossed = !opts.debug && !opts.verbose && !opts.quiet;
+  const loggerLevel = useFingersCrossed ? "debug" : flagBasedLevel;
+  const sink = useFingersCrossed
+    ? fingersCrossed(consoleSink, { triggerLevel: "error", maxBufferSize: 200 })
+    : consoleSink;
+  ```
+
+  **Design rationale**: `--verbose` users opted into seeing info-level output immediately. Buffering it behind fingers-crossed would suppress the output they asked for. Fingers-crossed is for the zero-flag default case where users want silence on success and diagnostics on failure.
+
+- [ ] `shutdownLogging()` already handles `dispose()` with timeout (from Phase 1) -- no changes needed. The fingers-crossed buffer is flushed by the existing shutdown path.
+
+- [ ] Test the auto-flush behavior
+  - Run with `--mock` + a scenario that triggers an error
+  - Verify debug-level logs appear on stderr only when an error occurs
+  - Verify success runs produce zero debug output
+
+**Success criteria**:
+- `wots "topic"` on success: zero debug output on stderr (only progress + final output)
+- `wots "topic"` on error: full debug trace auto-flushed to stderr before exit
+- `wots "topic" --quiet` on error: only the error message, no debug trace
+- `wots "topic" --debug`: all debug output immediately (bypass fingers-crossed)
+
+---
+
+#### Phase 4: Ecosystem (Optional, As-Needed)
+
+**Goal**: Add production-grade observability integrations when the use case arises.
+
+| Need | Package | Effort | Trigger |
+|------|---------|--------|---------|
+| Rotating log files | `@logtape/file` | ~30 min | `wots briefing` running on cron needs persistent logs |
+| OpenTelemetry export | `logtape-otel` | ~1 hour | Production observability pipeline (Axiom, Honeycomb) |
+| Sentry error tracking | `@logtape/sentry` | ~1 hour | Need error aggregation across users |
+| Config-from-file | `@logtape/config` | ~30 min | Power users want per-category debug without `--debug` flooding |
+| PII redaction | `@logtape/redaction` | ~30 min | Logs might contain usernames or API keys |
+
+**Not planned for v1**: These are documented here for future reference, not as part of this feature.
+
+## Alternative Approaches Considered
+
+### 1. Pino
+
+**Pros**: Smallest bundle (3.1 KB), industry standard for Node.js, massive ecosystem.
+**Cons**: Limited Bun support (unofficial), no no-op default (breaks library export pattern), JSON-only by default (requires `pino-pretty` dev dep for human output), no built-in async context (requires manual `child()` threading).
+**Why rejected**: The library-first no-op default is critical for wots's dual CLI/library export. Pino also lacks `fingersCrossed` and `withContext()`.
+
+### 2. Winston
+
+**Pros**: Most popular (12M+ weekly npm downloads), rich transport ecosystem, built-in formatters.
+**Cons**: 38.3 KB bundle with 17 dependencies, limited Bun support, no no-op default, no async context propagation.
+**Why rejected**: 17 dependencies is unacceptable for a CLI with one runtime dep. Bundle size is 7x LogTape.
+
+### 3. Console.error() with structured JSON
+
+**Pros**: Zero dependencies, zero learning curve, works everywhere.
+**Cons**: No level filtering, no async context, no formatter switching, no hierarchical categories, no fingers-crossed pattern, no library-first design.
+**Why rejected**: Doesn't solve the core problems (per-module verbosity, async context, auto-flush on error). Just a marginally better version of what we already have.
+
+### 4. Keep existing ad-hoc [debug] pattern
+
+**Pros**: No new dependency, no migration effort.
+**Cons**: Doesn't solve the http.ts race condition, cache silence, swallowed errors, or AI agent diagnostic needs. Maintains two disconnected debug systems.
+**Why rejected**: The status quo has real user-facing pain points.
+
+## System-Wide Impact
+
+### Interaction Graph
+
+- `cli.ts main()` calls `setupLogging()` which calls `configure()` -- this is a **global singleton** that affects all `getLogger()` calls in the process
+- In Phase 1, the sink is a direct console sink writing to stderr -- no buffering, no AsyncLocalStorage
+- Every `getLogger()` call in library code (`cache.ts`, `http.ts`, etc.) resolves to the configured sinks
+- `shutdownLogging()` is called on all exit paths (normal, error, SIGINT) via a single teardown function with 500ms timeout guard
+- Phase 2 adds `AsyncLocalStorage` for context propagation; Phase 3 adds fingers-crossed buffering
+
+### Error & Failure Propagation
+
+- **LogTape config failure**: If `configure()` throws (e.g., duplicate categories), the error propagates to `main()` and the CLI exits with `EXIT_RUNTIME`. Since `setupLogging()` is synchronous, this is a simple try/catch in main(). `shutdownLogging()` is safe to call after a failed setup (idempotent no-op when `configured === false`).
+- **Sink write failure**: LogTape logs sink errors to the meta logger (`["logtape", "meta"]`). A failing stderr write doesn't crash the CLI -- the log is silently dropped.
+- **`dispose()` failure**: If `dispose()` throws during shutdown, the try/finally in main() still completes. Buffered logs are lost but program output is unaffected.
+- **Double shutdown**: `shutdownLogging()` guards with a `configured` flag. Second call is a no-op.
+
+### State Lifecycle Risks
+
+- **AsyncLocalStorage leak**: `withContext()` scopes context to the callback's lifetime. If a `Promise.all()` branch leaks a promise that resolves after the scope closes, its logs lose context properties. This is non-critical -- logs still emit, just without the implicit context.
+- **Fingers-crossed buffer overflow**: Capped at `maxBufferSize: 200`. If a run generates 200+ debug messages before an error, the oldest are dropped. For wots's typical 20-50 log messages per run, this is well within bounds.
+
+### API Surface Parity
+
+- **CLI interface**: Existing `--debug` and `--quiet` flags change internal mechanism but preserve external behavior. `--verbose` deferred to Phase 2.
+- **Library export (`src/index.ts`)**: Zero change. Library consumers see no difference because LogTape is a no-op until configured.
+- **JSON envelope schema**: No change. LogTape writes to stderr, not stdout.
+- **Exit codes**: No change.
+- **Beat Reporter agent contract**: `--quiet` suppresses ProgressDisplay AND sets LogTape to `error` level. The agent's `--json --quiet` invocation pattern is preserved. **Critically, `error`-level messages still emit to stderr** -- if a search fails, the agent gets the error diagnostic even in quiet mode. Only `debug`, `info`, and `warn` are suppressed.
+
+### Integration Test Scenarios
+
+1. **Stderr suppression under --quiet**: Verify `stderr.not.toContain('researching')` still passes -- LogTape at `error` level produces no info/debug/warning output.
+2. **Error message format in stderr**: Verify `stderr.toContain('Invalid --emit')` still passes -- these are pre-LogTape validation errors that bypass `setupLogging()`.
+3. **JSON envelope on stdout unchanged**: Verify `--json` output structure is identical -- LogTape never touches stdout.
+4. **Non-TTY auto-detection**: Verify `Bun.spawnSync()` (non-TTY) still auto-switches to JSON mode -- LogTape formatter adapts but doesn't interfere with stdout auto-detection.
+5. **--mock mode**: Verify `--mock` still works with LogTape configured -- mock data path is independent of logging.
+
+## Acceptance Criteria
+
+> **Note:** Criteria are split by phase. Phase 1 criteria must pass before shipping v1.
+> Phase 2/3 criteria are documented for when those phases are implemented.
+
+### Phase 1 (v1) Functional Requirements
+
+- [ ] `@logtape/logtape` added as runtime dependency (second dep after `@side-quest/core`)
+- [ ] `src/lib/logging.ts` created with synchronous `setupLogging()` and async idempotent `shutdownLogging()`
+- [ ] All `[debug]` and `[DEBUG]` stderr writes replaced with `getLogger()` calls
+- [ ] `http.ts` module-level `DEBUG` race condition eliminated
+- [ ] Interactive TTY uses ANSI color formatter on stderr
+- [ ] `--json` mode and piped stderr uses JSON Lines formatter
+- [ ] `WOTS_LOG_FORMAT=text` env var override for test determinism in non-TTY
+- [ ] `--quiet` suppresses both ProgressDisplay and LogTape output (error level still emits)
+- [ ] Cache warnings include remediation context (what happened, what CLI did, whether user action needed)
+- [ ] `shutdownLogging()` called via try/finally in main() and SIGINT handler
+- [ ] `writeError()` is sole owner of user-facing errors; no `logger.error()` in Phase 1
+- [ ] ProgressDisplay constructor preserves backward-compatible positional overload
+
+### Phase 1 (v1) Non-Functional Requirements
+
+- [ ] Zero change to stdout output in any mode (compact, JSON, JSONL, markdown, context, path)
+- [ ] Zero change to exit codes
+- [ ] Zero change to JSON envelope schema
+- [ ] **Default mode parity**: All existing tests pass without modification when no new flags are active (verified via `WOTS_LOG_FORMAT=text` for non-TTY determinism)
+- [ ] **New flag tests**: Targeted test updates permitted for changed `[debug]` -> LogTape format
+- [ ] **Log invariant tests**: Dedicated `tests/log-invariants.test.ts` proving no logs leak to stdout, --quiet stderr is clean, no envelope fragments in stderr
+- [ ] Bundle size increase < 6 KB (LogTape is 5.3 KB min+gz)
+- [ ] No measurable latency increase on typical CLI runs (< 1ms total logging overhead)
+- [ ] Library export (`src/index.ts`) produces zero logging output when unconfigured
+
+### Phase 1 (v1) Quality Gates
+
+- [ ] `bun run validate` passes (lint + typecheck + build + test)
+- [ ] Integration tests covering --debug and --quiet modes with LogTape
+- [ ] No `[debug]` or `[DEBUG]` string literals remain in src/ or tests/ (clean migration -- audit both)
+- [ ] No `process.env.WOTS_DEBUG` writes remain in src/
+- [ ] `shutdownLogging()` unit tests pass: idempotent, pre-setup no-op, timeout guard, double-call safe
+- [ ] Log invariant tests pass in `tests/log-invariants.test.ts`
+- [ ] `--mock` tests produce no cache warnings (verified by clean stderr assertion)
+
+### Phase 2 (deferred) Acceptance Criteria
+
+- [ ] `withContext()` wraps each `Promise.all()` search branch
+- [ ] Cache operations logged at appropriate levels (hit=debug, miss=debug, stale=warn, error=warn)
+- [ ] All silent catch blocks logged per the error level matrix
+- [ ] AI agents can parse JSON Lines stderr to identify which source failed and why
+
+### Phase 3 (deferred) Acceptance Criteria
+
+- [ ] Fingers-crossed sink auto-flushes debug buffer on error
+- [ ] Integration test for fingers-crossed auto-flush on error
+
+## Success Metrics
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Debug systems | 2 (disconnected, race condition) | 1 (unified LogTape) |
+| Cache observability | 0 log messages | debug/warn per operation |
+| Silenced errors | 10+ catch blocks | 0 -- all logged at appropriate level |
+| AI agent diagnostics | Error message string only | Full structured JSON Lines trace |
+| User effort to debug | Re-run with source code changes | `--debug` flag |
+| Dependencies added | 0 | 1 (zero-dep, 5.3 KB) |
+
+## Dependencies & Prerequisites
+
+- `@logtape/logtape` ^2.0.0 (bounded range -- lockfile pins exact version; caret allows patch/minor updates)
+- Bun >= 1.2.0 (already required by wots)
+- No other prerequisites -- LogTape has zero dependencies
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| ProgressDisplay + LogTape interleaving on stderr | High (when --debug/--verbose active) | Medium (garbled terminal output) | Suppress ProgressDisplay spinners when `--verbose` or `--debug` is active. Replace with static "Phase: searching reddit..." lines. |
+| Existing tests break due to new stderr output | Medium | Low (quick fix) | LogTape at `warning` level by default produces nothing new. Tests use `--mock` which doesn't trigger warnings. Validate all tests before merging. |
+| Fingers-crossed sink + --quiet conflict | Medium (design ambiguity) | Low | `--quiet` disables fingers-crossed. If user wants quiet+auto-flush, they use default mode (no flags). Document in --help. |
+| `configure()` called twice (library consumer + cli.ts) | Low | Medium (ConfigError) | Document in README: "If importing wots as a library, configure LogTape before calling wots functions, OR let wots configure it via CLI." The library export never calls `configure()`. |
+| Pre-configuration errors miss LogTape | Low | Low | Arg parsing errors use existing error handling (pre-LogTape). This is acceptable -- these errors are user-facing validation messages, not diagnostic traces. |
+| Non-blocking mode data loss | N/A | N/A | Explicitly DO NOT use non-blocking mode. CLIs are short-lived -- blocking mode is correct. |
+
+### ProgressDisplay Interaction Strategy
+
+This is the highest-risk UX concern. Addressed in Phase 1 (the `ProgressDisplay` mode task).
+
+| Flag | ProgressDisplay Mode | LogTape Level | Phase 1 Behavior | Later Phases |
+|------|---------------------|---------------|------------------|--------------|
+| (none) | `animated` | `warning` | Spinners active, warnings with remediation context, no interleaving | Phase 3: fingers-crossed buffers `debug`; auto-flushes on error |
+| `--verbose` | `static` | `info` | **(Phase 2)** Static phase names, info logs between phases | Phase 2 adds lifecycle events; Phase 3: no fingers-crossed |
+| `--debug` | `off` | `debug` | LogTape debug output IS the progress indicator | Phase 3: bypass fingers-crossed |
+| `--quiet` | `off` | `error` | Both suppressed, only `error`-level messages appear | Phase 3: no fingers-crossed |
+
+**Flag precedence** (encoded in `resolveOutputMode()` helper):
+- `--debug` wins over `--quiet` (debug intent overrides silence)
+- `--quiet` wins over `--verbose` (silence intent overrides chattiness)
+- `--debug --verbose` => debug (debug is superset of verbose)
+- `--json` does not affect log level, only formatter selection
+
+### Backwards Compatibility Contract
+
+**Explicitly retired**: The `[debug]` and `[DEBUG]` prefix format. No consumers are known to parse this format. The Beat Reporter agent uses `--quiet` and never sees debug output.
+
+**Preserved**:
+- `--quiet` suppresses ProgressDisplay (tested in `field-projection.test.ts` line 251)
+- Validation error messages on stderr (tested in 15+ assertions in `index.test.ts`)
+- `--json` auto-detection when stdout is piped
+- All exit codes and JSON envelope schema
+
+## Resource Requirements
+
+- **Developer**: 1 person (Nathan)
+- **Estimated v1 effort**: ~3 hours (Phase 1 only)
+- **Estimated total effort**: ~7.5 hours if all three phases ship (evaluate after each)
+- **External dependencies**: None (LogTape is published, stable at v2.0.0+)
+- **CI changes**: None (existing `bun run validate` covers everything)
+
+## Future Considerations
+
+- **Phase 4 ecosystem packages**: File sinks for `wots briefing` cron, OTel for production pipelines, Sentry for error aggregation. These are documented but not planned.
+- **`@logtape/config` for power users**: Enable `--log-config=path` for per-category debug without `--debug` flooding everything. Add when users request it.
+- **Telemetry contract integration**: The existing `telemetry-contract.ts` defines structured event types. LogTape could serve as the transport layer for telemetry events in a future version, unifying observability and telemetry under one system.
+- **`@logtape/adaptor-pino`**: If a library consumer already uses Pino, the adaptor lets LogTape-instrumented wots code forward into their Pino pipeline. Document in README.
+
+## Documentation Plan
+
+- [ ] Add `wots help logging` topic (new) covering: flag mapping, JSON Lines format for agents, category hierarchy, library consumer configuration
+- [ ] Add "Observability" section to README with examples for human/agent/library consumers
+- [ ] Update README "Flags" section with `--verbose` (Phase 2, when flag ships)
+- [ ] Reference spec: `docs/logtape-cli-observability-spec.md` (already written, 17 sections, 700+ lines)
+
+## Sources & References
+
+### Origin
+
+- **Technical spec**: [docs/logtape-cli-observability-spec.md](/Users/nathanvale/code/side-quest-plugins/docs/logtape-cli-observability-spec.md) -- comprehensive LogTape evaluation covering architecture, implementation patterns, gotchas, performance, and comparison matrix. Written from research across official docs, community articles, and X posts.
+
+### Internal References
+
+- CLI entry point: `/Users/nathanvale/code/side-quest-last-30-days/src/cli.ts` (1313 lines)
+- Cache layer: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/cache.ts` (363 lines)
+- HTTP utilities: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/http.ts` (DEBUG race condition at lines 10-17)
+- Progress display: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/ui.ts` (304 lines)
+- Output modes: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/output.ts` (224 lines)
+- Arg parser: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/parse-args.ts`
+- Telemetry contract: `/Users/nathanvale/code/side-quest-last-30-days/src/lib/telemetry-contract.ts`
+- Integration tests (stderr assertions): `/Users/nathanvale/code/side-quest-last-30-days/tests/index.test.ts` (15+ stderr assertions)
+- Integration tests (progress suppression): `/Users/nathanvale/code/side-quest-last-30-days/tests/field-projection.test.ts:251`
+
+### External References
+
+- [LogTape documentation](https://logtape.org/) -- official docs
+- [LogTape GitHub](https://github.com/dahlia/logtape) -- source, issues, discussions
+- [Logging in Node.js/Deno/Bun 2026](https://hackers.pub/@hongminhee/2026/logging-nodejs-deno-bun-2026) -- author's guide
+- [Trace-Connected Structured Logging with LogTape and Sentry](https://blog.sentry.io/trace-connected-structured-logging-with-logtape-and-sentry/) -- Sentry integration
+- [LogTape comparison table](https://logtape.org/comparison) -- benchmarks vs alternatives
+
+### Related Work
+
+- Newsroom Beat Reporter agent: `/Users/nathanvale/code/side-quest-plugins/plugins/newsroom/agents/beat-reporter.md` -- primary consumer of wots --json --quiet

--- a/docs/research/logtape-cli-observability-spec.md
+++ b/docs/research/logtape-cli-observability-spec.md
@@ -1,0 +1,1301 @@
+# LogTape Observability for CLI Tools
+
+## A Staff Engineer's Technical Specification
+
+**Status**: Draft
+**Author**: Nathan Vale
+**Date**: 2026-02-25
+**Scope**: Structured logging, AI-agent observability, and production debugging for Bun CLI tools -- with `@side-quest/word-on-the-street` (wots) as the reference implementation.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Why Logging in CLI Tools is Different](#2-why-logging-in-cli-tools-is-different)
+3. [Why LogTape](#3-why-logtape)
+4. [Core Concepts](#4-core-concepts)
+5. [Architecture for CLI Tools](#5-architecture-for-cli-tools)
+6. [Implementation Guide](#6-implementation-guide)
+7. [AI Agent Observability](#7-ai-agent-observability)
+8. [Testing](#8-testing)
+9. [The Library/CLI Boundary](#9-the-librarycli-boundary)
+10. [Gotchas and Pitfalls](#10-gotchas-and-pitfalls)
+11. [When NOT to Use LogTape](#11-when-not-to-use-logtape)
+12. [Migration Guide](#12-migration-guide)
+13. [Performance](#13-performance)
+14. [Comparison Matrix](#14-comparison-matrix)
+15. [Decision Framework](#15-decision-framework)
+16. [Resources](#16-resources)
+17. [Glossary](#17-glossary)
+
+---
+
+## 1. Executive Summary
+
+LogTape is a zero-dependency, runtime-agnostic structured logging library designed with a "library-first" philosophy. Its defining property: **if nobody calls `configure()`, all logging is a silent no-op.** This makes it uniquely suited to CLI tools that serve three audiences simultaneously:
+
+1. **Humans** running the CLI interactively (want clean output, no noise)
+2. **Developers** debugging failures (want structured context, async traces)
+3. **AI agents** calling the CLI as a subprocess (want machine-readable diagnostics)
+
+This spec documents everything a staff engineer needs to evaluate, adopt, and operate LogTape in a Bun CLI tool -- covering architecture, implementation patterns, gotchas, performance, and the specific concerns of AI-agent observability.
+
+---
+
+## 2. Why Logging in CLI Tools is Different
+
+### 2.1 The Fundamental Tension
+
+Backend servers have one output consumer: a log aggregator. CLIs have three:
+
+| Consumer | Wants | Channel |
+|----------|-------|---------|
+| End user | Clean program output, no noise | `stdout` |
+| Developer | Structured debug context | `stderr` |
+| AI agent | Machine-parseable diagnostics | `stderr` (JSON Lines) |
+
+**Rule #1**: Program output goes to `stdout`. Logs go to `stderr`. Always. This lets `wots "topic" | jq .` work while debug logs appear alongside.
+
+### 2.2 CLIs vs Backends -- Key Differences
+
+| Concern | Backend Server | CLI Tool |
+|---------|---------------|----------|
+| Default output | JSON Lines to aggregator | Human-readable to stderr |
+| stdout | N/A (or health checks) | Sacred -- reserved for program output |
+| Lifetime | Long-running process | Seconds to minutes |
+| Verbosity control | Per-service config file | `--verbose` / `--debug` flags |
+| Config source | Environment vars, config service | CLI args or `--log-config=path` |
+| Default formatter | Always JSON Lines | Human-readable; JSON when piped |
+| Log volume | High (requests/sec) | Low (one run = one execution) |
+| Buffering tradeoff | Throughput > durability ok | Durability > throughput (short-lived) |
+| Consumer | Machines (Datadog, Grafana) | Humans (terminal) + AI agents |
+| Shutdown | Graceful drain period | Process exits immediately |
+
+### 2.3 The Three Output Tiers
+
+A well-designed CLI has distinct output tiers. LogTape replaces tier 2, not tier 1 or tier 3:
+
+```
+Tier 1: Program output (stdout)
+  - The actual result: JSON envelopes, compact tables, markdown
+  - NEVER touched by logging
+
+Tier 2: Diagnostic output (stderr)         <-- LogTape lives here
+  - Progress indicators, debug messages, warnings
+  - Controlled by --verbose / --debug / --quiet
+
+Tier 3: Side-channel output (files, telemetry)
+  - Rotating log files, OpenTelemetry spans
+  - For post-mortem analysis
+```
+
+---
+
+## 3. Why LogTape
+
+### 3.1 The Selection Criteria
+
+For a Bun CLI tool, the logging library must satisfy:
+
+1. **Zero-dependency** -- CLI tools are distributed via `bunx`; every dependency is download time
+2. **No-op by default** -- library consumers who don't configure logging must see zero output
+3. **First-class Bun support** -- not "works on Bun" but "tested and benchmarked on Bun"
+4. **Structured + human-readable** -- same log call, different formatters per context
+5. **Async context propagation** -- `Promise.all()` orchestration needs implicit context
+6. **Small bundle** -- CLI cold start matters
+
+### 3.2 How LogTape Meets Each Criterion
+
+| Criterion | LogTape | Pino | Winston |
+|-----------|---------|------|---------|
+| Dependencies | 0 | 1 | 17 |
+| Bundle (min+gz) | 5.3 KB | 3.1 KB | 38.3 KB |
+| No-op default | Yes (core design) | No (requires config) | No |
+| Bun support | Full (official) | Limited (unofficial) | Limited |
+| Structured logging | Yes | Yes | Yes |
+| Async context | `withContext()` + `AsyncLocalStorage` | Via `pino.child()` (manual) | Via `child()` (manual) |
+| Tree-shakable | Yes | No | No |
+| Human formatter | Built-in (ANSI, text) | Requires `pino-pretty` (dev dep) | Built-in |
+| JSON formatter | Built-in (`jsonLinesFormatter`) | Default (JSON only) | Built-in |
+
+### 3.3 The "Library-First" Design
+
+This is LogTape's philosophical differentiator. From the author (Hong Minhee):
+
+> LogTape was created because I needed logging in Fedify (an ActivityPub library) without forcing end-users to configure anything. If a Fedify user never calls `configure()`, they see zero output, zero warnings, zero overhead.
+
+For CLI tools that are also importable as libraries (like wots with its `src/index.ts` barrel export), this is critical. The library export has `getLogger()` calls throughout, but consumers who `import { searchReddit } from "@side-quest/word-on-the-street"` never see log output unless they opt in.
+
+---
+
+## 4. Core Concepts
+
+### 4.1 Categories (Hierarchical Namespacing)
+
+Categories are string arrays forming a tree. Log messages propagate upward to parent loggers:
+
+```typescript
+import { getLogger } from "@logtape/logtape";
+
+// These form a hierarchy:
+const root   = getLogger(["wots"]);
+const cache  = getLogger(["wots", "cache"]);
+const reddit = getLogger(["wots", "search", "reddit"]);
+
+// A log from ["wots", "search", "reddit"] reaches:
+//   - ["wots", "search", "reddit"]  (exact match)
+//   - ["wots", "search"]            (parent)
+//   - ["wots"]                      (grandparent)
+```
+
+**Why this matters for CLIs**: You can set `["wots"]` to `"warning"` for normal use, but dial `["wots", "search", "reddit"]` to `"debug"` when investigating a specific search failure -- without touching other categories.
+
+### 4.2 Sinks (Where Logs Go)
+
+A sink is a function `(record: LogRecord) => void`. LogTape provides built-in sinks and you can write custom ones:
+
+| Sink | Use Case | Package |
+|------|----------|---------|
+| Console | Development, interactive CLI | `@logtape/logtape` (built-in) |
+| Stream | Write to `process.stderr` as a `WritableStream` | `@logtape/logtape` (built-in) |
+| File | Persistent log files | `@logtape/file` |
+| Rotating File | Size/time-based rotation | `@logtape/file` |
+| OpenTelemetry | Production observability | `logtape-otel` |
+| Sentry | Error tracking + traces | `@logtape/sentry` |
+| CloudWatch | AWS logging | `@logtape/cloudwatch-logs` |
+| Custom | Anything | Inline function |
+
+**CLI-specific pattern**: Use Console sink to stderr for interactive mode, Stream sink with JSON Lines formatter when stdout is piped:
+
+```typescript
+import {
+  configure,
+  getConsoleSink,
+  getStreamSink,
+} from "@logtape/logtape";
+import stream from "node:stream";
+
+const isPiped = !process.stderr.isTTY;
+
+await configure({
+  sinks: {
+    stderr: isPiped
+      ? getStreamSink(stream.Writable.toWeb(process.stderr), {
+          formatter: jsonLinesFormatter,
+        })
+      : getConsoleSink(),
+  },
+  loggers: [
+    { category: ["wots"], sinks: ["stderr"], lowestLevel: "warning" },
+  ],
+});
+```
+
+### 4.3 Formatters (How Logs Look)
+
+Three built-in formatters, each serving a different consumer:
+
+**Default Text Formatter** -- human-readable:
+```
+2026-02-25 10:34:10.465 +11:00 [INF] wots·search·reddit: Search started
+```
+
+**ANSI Color Formatter** -- colorized terminal output:
+```
+2026-02-25 10:34:10.465 +11 INF wots·search·reddit: Search started
+```
+(With color codes for level, category, and timestamps)
+
+**JSON Lines Formatter** -- machine-readable:
+```json
+{"@timestamp":"2026-02-25T10:34:10.465Z","level":"INFO","category":"wots.search.reddit","message":"Search started","topic":"Claude Code","source":"reddit"}
+```
+
+**Pretty Formatter** (via `@logtape/pretty`) -- development output with emojis and alignment:
+```
+ INFO wots > search > reddit  Search started  topic=Claude Code
+```
+
+### 4.4 Contexts (The Killer Feature for CLIs)
+
+Contexts attach key-value properties to log messages without threading them through function signatures.
+
+**Explicit context** -- set on a logger instance:
+
+```typescript
+const logger = getLogger(["wots", "search"]);
+const ctx = logger.with({ topic: "Claude Code", depth: "deep" });
+ctx.info("Search started");
+// Output: ... Search started  topic=Claude Code  depth=deep
+```
+
+**Implicit context** -- propagates across async boundaries:
+
+```typescript
+import { withContext } from "@logtape/logtape";
+
+// Set once at the top of the call stack
+withContext({ topic: "Claude Code", runId: "abc123" }, async () => {
+  // Every log message in this async tree gets topic + runId
+  await searchReddit();   // logs here carry the context
+  await searchX();        // logs here carry the context too
+  await searchYouTube();  // and here
+});
+```
+
+**Lazy context** -- evaluated at log time, not at creation:
+
+```typescript
+import { lazy } from "@logtape/logtape";
+
+const logger = getLogger(["wots"]).with({
+  elapsed: lazy(() => `${Date.now() - startTime}ms`),
+});
+```
+
+**Priority order** (highest to lowest):
+1. Log message properties (inline)
+2. Explicit context (`.with()`)
+3. Implicit context (`withContext()`)
+
+### 4.5 Levels
+
+Six severity levels, highest to lowest:
+
+| Level | Method | CLI Use Case |
+|-------|--------|-------------|
+| `fatal` | `logger.fatal()` | Unrecoverable errors (process will exit) |
+| `error` | `logger.error()` | Operation failed but process continues |
+| `warning` | `logger.warn()` | Degraded operation (stale cache, rate limit) |
+| `info` | `logger.info()` | Key lifecycle events (search started/completed) |
+| `debug` | `logger.debug()` | Detailed internal state (cache hits, API payloads) |
+| `trace` | `logger.trace()` | Extremely verbose (scoring loop iterations) |
+
+**CLI mapping**:
+- No flags: `lowestLevel: "warning"` (only problems surface)
+- `--verbose`: `lowestLevel: "info"` (lifecycle events)
+- `--debug`: `lowestLevel: "debug"` (full diagnostic detail)
+
+### 4.6 Log Message Syntax
+
+Two styles, both producing structured output:
+
+**Template literals** (concise, great for simple messages):
+```typescript
+logger.info`Search completed: ${count} items from ${source}`;
+```
+
+**Function calls** (structured, named properties):
+```typescript
+logger.info("Search completed: {count} items from {source}", {
+  count: items.length,
+  source: "reddit",
+  cacheHit: fromCache,
+});
+```
+
+The function call style is preferred for CLI tools because:
+1. Property names are explicit (not positional)
+2. You can add properties that aren't in the message template
+3. AI agents can parse the structured properties
+
+### 4.7 Lazy Evaluation
+
+Defer expensive computations so they only run if the level is enabled:
+
+```typescript
+// This computes even if debug is disabled:
+logger.debug("Cache stats: {stats}", { stats: computeStats() });  // BAD
+
+// This only computes if debug is enabled:
+logger.debug(l => l`Cache stats: ${computeStats()}`);              // GOOD
+
+// Or with function call style:
+logger.debug("Cache stats: {stats}", () => ({
+  stats: computeStats(),
+}));
+```
+
+For async operations, check the level first:
+
+```typescript
+if (logger.isEnabledFor("debug")) {
+  const stats = await fetchRemoteStats();
+  logger.debug("Remote stats: {stats}", { stats });
+}
+```
+
+### 4.8 Fingers Crossed Sink
+
+A powerful pattern for CLI tools: buffer debug/trace logs silently, but **flush the entire buffer when an error occurs**. This gives you full diagnostic context on failures without noise on success:
+
+```typescript
+import { configure, fingersCrossed, getConsoleSink } from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: fingersCrossed(getConsoleSink(), {
+      triggerLevel: "error",     // Flush buffer when error+ is logged
+      maxBufferSize: 500,        // Cap buffered records
+    }),
+  },
+  loggers: [
+    { category: ["wots"], sinks: ["console"], lowestLevel: "debug" },
+  ],
+});
+```
+
+**How it works**:
+1. Debug and info logs are silently buffered
+2. When an error or fatal log arrives, the entire buffer is flushed
+3. Subsequent logs pass through immediately (the "crossed" state)
+
+**CLI use case**: Run `wots "topic"` -- on success, no debug noise. On failure, you get the full debug trace leading up to the error. No `--debug` flag needed.
+
+**Isolation modes**:
+- `isolateByCategory: "descendant"` -- separate buffers per category subtree
+- `isolateByContext: { keys: ["requestId"] }` -- separate buffers per context value
+
+---
+
+## 5. Architecture for CLI Tools
+
+### 5.1 Category Hierarchy Design
+
+Design categories around your CLI's functional boundaries, not file structure:
+
+```
+wots                          # Root -- catch-all
+├── wots.cli                  # Arg parsing, flag resolution, entry/exit
+├── wots.cache                # Cache hits, misses, stale fallbacks, locks
+├── wots.search               # Search orchestration
+│   ├── wots.search.reddit    # OpenAI Responses API calls
+│   ├── wots.search.x         # xAI API calls
+│   ├── wots.search.youtube   # yt-dlp invocations
+│   └── wots.search.web       # Web search instructions
+├── wots.score                # Relevance/recency/engagement scoring
+├── wots.render               # Output formatting decisions
+└── wots.watchlist            # SQLite ops, briefing generation
+```
+
+**Naming rules**:
+- Start with your package name (`wots`) to avoid collisions
+- Use functional boundaries, not file names
+- Keep depth to 3 levels max (root.domain.subdomain)
+- The root category is the single knob for "all logging on/off"
+
+### 5.2 Sink Configuration Strategy
+
+```typescript
+// src/logging.ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  type LogRecord,
+  ansiColorFormatter,
+  configure,
+  getConsoleSink,
+  getTextFormatter,
+  jsonLinesFormatter,
+} from "@logtape/logtape";
+
+export interface LoggingOptions {
+  debug: boolean;
+  verbose: boolean;
+  quiet: boolean;
+  json: boolean;
+}
+
+/**
+ * Configure LogTape for CLI execution.
+ *
+ * Selects formatter based on output mode:
+ * - Interactive TTY: ANSI color formatter to stderr
+ * - JSON mode (--json/--jsonl) or piped: JSON Lines to stderr
+ * - Quiet mode: errors only
+ */
+export async function setupLogging(opts: LoggingOptions): Promise<void> {
+  const level = opts.debug
+    ? "debug"
+    : opts.verbose
+      ? "info"
+      : opts.quiet
+        ? "error"
+        : "warning";
+
+  const isInteractive = process.stderr.isTTY && !opts.json;
+
+  await configure({
+    // Enable implicit context propagation for async operations
+    contextLocalStorage: new AsyncLocalStorage(),
+    sinks: {
+      stderr: getConsoleSink({
+        formatter: isInteractive ? ansiColorFormatter : jsonLinesFormatter,
+      }),
+    },
+    loggers: [
+      {
+        category: ["wots"],
+        sinks: ["stderr"],
+        lowestLevel: level,
+      },
+    ],
+  });
+}
+```
+
+### 5.3 Flag-to-Level Mapping
+
+| User Intent | Flag | Level | What They See |
+|------------|------|-------|---------------|
+| Normal use | (none) | `warning` | Only problems |
+| Curious | `--verbose` | `info` | Lifecycle events |
+| Debugging | `--debug` | `debug` | Full diagnostic detail |
+| Silent | `--quiet` | `error` | Only errors |
+| AI agent | `--json --quiet` | `error` + JSON | Machine-readable errors only |
+| AI agent debugging | `--json --debug` | `debug` + JSON | Full structured diagnostics |
+
+### 5.4 The Config-from-File Pattern
+
+LogTape 2.0 ships `@logtape/config` for external configuration. This enables power-user workflows:
+
+```bash
+# User creates a custom logging config
+cat > ~/.config/wots/logtape.json << 'EOF'
+{
+  "sinks": {
+    "console": { "$factory": "#console" },
+    "file": { "$factory": "@logtape/file#getFileSink", "path": "/tmp/wots.log" }
+  },
+  "loggers": [
+    { "category": ["wots"], "sinks": ["console"], "lowestLevel": "warning" },
+    { "category": ["wots", "search", "reddit"], "sinks": ["file"], "lowestLevel": "debug" }
+  ]
+}
+EOF
+
+# Use it
+wots "Claude Code" --log-config=~/.config/wots/logtape.json
+```
+
+**When to add this**: Not in v1. Add it when users request per-category debugging without `--debug` flooding everything.
+
+---
+
+## 6. Implementation Guide
+
+### 6.1 Installation
+
+```bash
+bun add @logtape/logtape
+```
+
+This is the only required package. Ecosystem packages are optional:
+
+| Package | When to Add |
+|---------|------------|
+| `@logtape/file` | If you want rotating file sinks |
+| `@logtape/otel` | If you want OpenTelemetry export |
+| `@logtape/sentry` | If you want Sentry error tracking |
+| `@logtape/config` | If you want config-from-file |
+| `@logtape/redaction` | If logs might contain PII |
+| `@logtape/pretty` | If you want emoji-rich dev output |
+
+### 6.2 Entry Point Wiring
+
+Call `setupLogging()` as the first async operation in your CLI's `main()`:
+
+```typescript
+// src/cli.ts
+import { setupLogging } from "./logging";
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["wots", "cli"]);
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Configure logging before anything else
+  await setupLogging({
+    debug: args.debug,
+    verbose: args.verbose ?? false,
+    quiet: args.quiet,
+    json: args.json || args.jsonl,
+  });
+
+  logger.info("CLI started: {topic} (depth={depth}, sources={sources})", {
+    topic: args.topic,
+    depth: args.depth,
+    sources: args.sources,
+  });
+
+  // ... rest of CLI logic
+}
+```
+
+### 6.3 Wrapping Parallel Search Tasks with Context
+
+This is where LogTape's value is most visible. The wots CLI runs Reddit, X, and YouTube searches in parallel via `Promise.all()`. Wrapping each with `withContext()` gives every log message inside the search automatic source identification:
+
+```typescript
+import { withContext, getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["wots", "search"]);
+
+const promises: Promise<void>[] = [];
+
+if (runReddit) {
+  promises.push(
+    withContext({ source: "reddit", topic }, async () => {
+      logger.info("Search started");
+
+      const result = await searchRedditTask(/* ... */);
+
+      if (result.fromCache) {
+        logger.debug("Cache hit (age={ageHours}h)", {
+          ageHours: result.cacheAgeHours,
+        });
+      }
+
+      if (result.rateLimited) {
+        logger.warn("Rate limited (stale={usedStale}, age={ageHours}h)", {
+          usedStale: result.usedStaleCache,
+          ageHours: result.cacheAgeHours,
+        });
+      }
+
+      if (result.error) {
+        logger.error("Search failed: {error}", { error: result.error });
+      }
+
+      logger.info("Search complete: {count} items", {
+        count: result.items.length,
+        fromCache: result.fromCache,
+      });
+
+      redditItems = result.items;
+    })
+  );
+}
+
+// X and YouTube follow the same pattern...
+
+await Promise.all(promises);
+```
+
+**What this produces** (with `--debug --json`):
+
+```jsonl
+{"@timestamp":"...","level":"INFO","category":"wots.search","message":"Search started","source":"reddit","topic":"Claude Code"}
+{"@timestamp":"...","level":"DEBUG","category":"wots.search","message":"Cache hit (age=2.3h)","source":"reddit","topic":"Claude Code","ageHours":2.3}
+{"@timestamp":"...","level":"INFO","category":"wots.search","message":"Search started","source":"x","topic":"Claude Code"}
+{"@timestamp":"...","level":"WARN","category":"wots.search","message":"Rate limited (stale=true, age=18.2h)","source":"x","topic":"Claude Code","usedStale":true,"ageHours":18.2}
+```
+
+An AI agent reading this stderr stream can immediately identify: Reddit succeeded from cache, X was rate-limited and served stale data.
+
+### 6.4 Cache Logging
+
+The cache layer is high-value for structured logging -- it's where most "why is my data stale?" questions get answered:
+
+```typescript
+// src/lib/cache.ts
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["wots", "cache"]);
+
+export function loadCache(key: string): CacheResult | null {
+  const entry = readCacheFile(key);
+
+  if (!entry) {
+    logger.debug("Cache miss: {key}", { key });
+    return null;
+  }
+
+  if (isExpired(entry)) {
+    logger.debug("Cache expired: {key} (age={ageHours}h, ttl={ttlHours}h)", {
+      key,
+      ageHours: entry.ageHours,
+      ttlHours: entry.ttlHours,
+    });
+    return null;
+  }
+
+  logger.debug("Cache hit: {key} (age={ageHours}h, version={version})", {
+    key,
+    ageHours: entry.ageHours,
+    version: entry.version,
+  });
+  return entry.data;
+}
+```
+
+### 6.5 What NOT to Log
+
+| Don't Log | Why | Instead |
+|-----------|-----|---------|
+| Raw API responses | Huge, may contain user data | Log item counts and status codes |
+| Scoring loop iterations | 50+ items * multiple factors = noise | Log final top-5 scores |
+| Every cache key check | High frequency, low signal | Log hits and misses only |
+| Progress display updates | These are UI, not diagnostics | Keep `ProgressDisplay` on stderr as-is |
+| API keys or tokens | Security risk | Log `"key=present"` / `"key=missing"` |
+
+---
+
+## 7. AI Agent Observability
+
+### 7.1 The Problem
+
+When a Claude Code sub-agent runs `wots "Claude Code" --json --quiet`, it gets a JSON envelope on stdout. If the envelope contains `"status": "error"`, the agent has no diagnostic context -- just an error message.
+
+### 7.2 The Solution
+
+With LogTape, the agent can run `wots "Claude Code" --json --debug` and parse structured JSON Lines from stderr:
+
+```typescript
+// Agent-side pseudocode
+const proc = Bun.spawn(["wots", topic, "--json", "--debug"], {
+  stdout: "pipe",
+  stderr: "pipe",
+});
+
+const result = JSON.parse(await new Response(proc.stdout).text());
+const diagnostics = (await new Response(proc.stderr).text())
+  .split("\n")
+  .filter(Boolean)
+  .map(line => JSON.parse(line));
+
+if (result.status === "error") {
+  // diagnostics contains the full structured trace:
+  // - Which sources were attempted
+  // - Which ones failed and why
+  // - Cache state at time of failure
+  // - Rate limit details
+}
+```
+
+### 7.3 Context Properties for Agent Consumption
+
+Design context properties that agents can programmatically filter:
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `source` | `"reddit" \| "x" \| "youtube" \| "web"` | Which search source |
+| `topic` | `string` | The search topic |
+| `phase` | `"search" \| "score" \| "render"` | Pipeline stage |
+| `fromCache` | `boolean` | Whether result came from cache |
+| `rateLimited` | `boolean` | Whether source was rate-limited |
+| `usedStaleCache` | `boolean` | Whether stale cache was served |
+| `cacheAgeHours` | `number` | How old the cached data is |
+| `itemCount` | `number` | Number of results returned |
+
+### 7.4 The `withContext()` + `Promise.all()` Pattern
+
+This is the core observability pattern for CLI tools that orchestrate parallel async work:
+
+```
+┌──────────────┐
+│  main()      │  context: { topic: "Claude Code", runId: "abc" }
+│              │
+│  ┌───────────┤
+│  │ Promise.all([
+│  │   withContext({ source: "reddit" }, searchReddit),
+│  │   withContext({ source: "x" }, searchX),
+│  │   withContext({ source: "youtube" }, searchYouTube),
+│  │ ])
+│  │
+│  │  Each branch inherits { topic, runId } and adds { source }
+│  │  Every log inside carries all three properties automatically
+│  └───────────┤
+└──────────────┘
+```
+
+### 7.5 Sentry Integration for Long-Running CLI Processes
+
+For CLI daemons (like `wots briefing` on a cron), add Sentry for error tracking:
+
+```typescript
+import * as Sentry from "@sentry/bun";
+import { getSentrySink } from "@logtape/sentry";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// CRITICAL: Initialize Sentry BEFORE LogTape
+Sentry.init({ dsn: "..." });
+
+await configure({
+  contextLocalStorage: new AsyncLocalStorage(),
+  sinks: {
+    console: getConsoleSink(),
+    sentry: getSentrySink({
+      contextLocalStorage: new AsyncLocalStorage(),
+    }),
+  },
+  loggers: [
+    { category: ["wots"], sinks: ["console", "sentry"], lowestLevel: "warning" },
+  ],
+});
+```
+
+**Gotcha**: Sentry must be initialized before `configure()`. If reversed, the Sentry sink silently drops all events. No error is thrown.
+
+---
+
+## 8. Testing
+
+### 8.1 Reset Between Tests
+
+LogTape is a global singleton. Reset it between tests to prevent leakage:
+
+```typescript
+import { configure, reset } from "@logtape/logtape";
+import { afterEach, beforeEach, describe, it, expect } from "bun:test";
+
+describe("searchReddit", () => {
+  const buffer: LogRecord[] = [];
+
+  beforeEach(async () => {
+    buffer.length = 0;
+    await configure({
+      sinks: {
+        buffer: buffer.push.bind(buffer),
+      },
+      loggers: [
+        { category: ["wots"], sinks: ["buffer"], lowestLevel: "debug" },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await reset();
+  });
+
+  it("logs cache hit on cached result", async () => {
+    await searchReddit("Claude Code", { fromCache: true });
+
+    const cacheLog = buffer.find(
+      (r) => r.category.join(".") === "wots.cache"
+        && r.level === "debug"
+    );
+    expect(cacheLog).toBeDefined();
+  });
+});
+```
+
+### 8.2 Buffer Sink Pattern
+
+LogTape doesn't ship a built-in memory sink, but the pattern is trivial:
+
+```typescript
+const buffer: LogRecord[] = [];
+
+await configure({
+  sinks: {
+    buffer: buffer.push.bind(buffer),
+  },
+  loggers: [
+    { category: ["wots"], sinks: ["buffer"], lowestLevel: "trace" },
+  ],
+});
+```
+
+### 8.3 Testing Implicit Contexts
+
+When testing code that uses `withContext()`, you must configure `contextLocalStorage`:
+
+```typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+
+beforeEach(async () => {
+  await configure({
+    contextLocalStorage: new AsyncLocalStorage(),
+    sinks: { buffer: buffer.push.bind(buffer) },
+    loggers: [
+      { category: ["wots"], sinks: ["buffer"], lowestLevel: "debug" },
+    ],
+  });
+});
+```
+
+### 8.4 What to Assert On
+
+| Assert | Don't Assert |
+|--------|-------------|
+| Log level is correct for the event | Exact message text (brittle) |
+| Category matches expected module | Timestamp values |
+| Context properties are present | Log ordering across parallel tasks |
+| Error logs include error details | Number of debug logs (implementation detail) |
+
+---
+
+## 9. The Library/CLI Boundary
+
+### 9.1 The Dual-Export Pattern
+
+wots has two entry points:
+
+```
+src/cli.ts    -- CLI entry point (owns I/O, configures LogTape)
+src/index.ts  -- Library barrel export (pure, no side effects)
+```
+
+**Rules**:
+- `cli.ts` calls `configure()`. Nobody else does.
+- Library code (`src/lib/*.ts`) calls `getLogger()` freely.
+- If a consumer imports from `@side-quest/word-on-the-street`, they configure their own LogTape -- or don't, and get silence.
+
+### 9.2 Library Authors: What to Do
+
+```typescript
+// src/lib/openai-reddit.ts
+import { getLogger } from "@logtape/logtape";
+
+// Use your package name as the root category
+const logger = getLogger(["wots", "search", "reddit"]);
+
+export async function searchReddit(topic: string): Promise<RedditResult> {
+  logger.info("Calling OpenAI Responses API: {topic}", { topic });
+  // ...
+}
+```
+
+### 9.3 Library Authors: What NOT to Do
+
+```typescript
+// NEVER do this in library code:
+import { configure } from "@logtape/logtape";
+await configure({ /* ... */ });  // Conflicts with consumer's config
+
+// NEVER do this:
+console.log("Debug: searching reddit");  // Not structured, not suppressible
+
+// NEVER do this:
+if (process.env.DEBUG) { /* ... */ }  // Side-channel, not LogTape-aware
+```
+
+### 9.4 Consumer Configuration
+
+When someone imports wots as a library, they control logging:
+
+```typescript
+import { configure, getConsoleSink } from "@logtape/logtape";
+import { searchReddit } from "@side-quest/word-on-the-street";
+
+// Consumer configures LogTape for their app
+await configure({
+  sinks: { console: getConsoleSink() },
+  loggers: [
+    // See wots internal logs at debug level
+    { category: ["wots"], sinks: ["console"], lowestLevel: "debug" },
+    // Or suppress them entirely
+    // { category: ["wots"], sinks: [], lowestLevel: "fatal" },
+  ],
+});
+
+const result = await searchReddit("Claude Code");
+```
+
+---
+
+## 10. Gotchas and Pitfalls
+
+### 10.1 Non-Blocking Mode Loses Logs on Crash
+
+LogTape's non-blocking mode buffers logs asynchronously. If the process hard-crashes (segfault, `process.exit(1)`), unwritten buffered logs are lost.
+
+**Mitigation**: Don't use `nonBlocking: true` for CLI tools. CLIs are short-lived -- the throughput gain doesn't justify the durability risk. Reserve non-blocking mode for high-throughput backend servers.
+
+```typescript
+// CLI: use blocking mode (default)
+getConsoleSink()
+
+// Backend: non-blocking is fine
+getConsoleSink({ nonBlocking: { bufferSize: 1000, flushInterval: 50 } })
+```
+
+### 10.2 Edge Function Teardown
+
+If wots ever runs in Cloudflare Workers or similar edge runtimes, you must explicitly call `dispose()` inside `ctx.waitUntil()`. Skip this and logs vanish on worker termination.
+
+```typescript
+import { dispose } from "@logtape/logtape";
+
+export default {
+  async fetch(request, env, ctx) {
+    await configure({ /* ... */ });
+    ctx.waitUntil(dispose());
+    return new Response("...");
+  }
+};
+```
+
+**For CLI tools**: Not relevant. The process lifecycle handles cleanup.
+
+### 10.3 Sentry Init Order
+
+If using `@logtape/sentry`, **Sentry must be initialized before LogTape's `configure()`**. Reversing the order causes silent event loss -- no error, no warning.
+
+```typescript
+// CORRECT:
+Sentry.init({ dsn: "..." });
+await configure({ sinks: { sentry: getSentrySink() } });
+
+// WRONG (silently drops Sentry events):
+await configure({ sinks: { sentry: getSentrySink() } });
+Sentry.init({ dsn: "..." });
+```
+
+### 10.4 OpenTelemetry Nested Object Serialization
+
+A bug fixed in Jan 2026 caused `logtape-otel` to flatten nested objects to JSON strings instead of proper `map<string, AnyValue>` structures. This broke queryability in backends like Axiom and Honeycomb. Ensure you're on the latest `logtape-otel` version.
+
+### 10.5 Redaction is Partial
+
+LogTape's `@logtape/redaction` supports pattern-based masking, but the docs explicitly note it's "not foolproof." Don't rely on it as your sole PII protection -- sanitize sensitive data before it reaches log calls.
+
+### 10.6 Duplicate Categories Cause ConfigError
+
+Configuring the same category twice in the `loggers` array throws `ConfigError`:
+
+```typescript
+// WRONG: duplicate category
+loggers: [
+  { category: ["wots", "search"], sinks: ["console"], lowestLevel: "info" },
+  { category: ["wots", "search"], sinks: ["file"], lowestLevel: "debug" },  // THROWS
+]
+
+// CORRECT: one entry, multiple sinks
+loggers: [
+  { category: ["wots", "search"], sinks: ["console", "file"], lowestLevel: "debug" },
+]
+```
+
+### 10.7 Don't Mix Sync and Async Configuration
+
+`configure()` / `reset()` and `configureSync()` / `resetSync()` are separate tracks. Never mix them:
+
+```typescript
+// WRONG:
+await configure({ /* ... */ });
+resetSync();  // Undefined behavior
+
+// CORRECT:
+await configure({ /* ... */ });
+await reset();
+```
+
+### 10.8 Bun Stream Sink Requires Manual WritableStream
+
+Unlike Node.js and Deno, Bun doesn't expose `process.stderr` as a `WritableStream`. You must wrap it manually:
+
+```typescript
+// Node.js: clean
+import stream from "node:stream";
+getStreamSink(stream.Writable.toWeb(process.stderr))
+
+// Bun: requires manual WritableStream wrapper
+let writer: FileSink | undefined;
+const stderrStream = new WritableStream({
+  start() { writer = Bun.stderr.writer(); },
+  write(chunk) { writer?.write(chunk); },
+  close() { writer?.close(); },
+});
+getStreamSink(stderrStream)
+
+// Simpler alternative: just use getConsoleSink() with a formatter
+// Console sink works fine on Bun without wrapping
+getConsoleSink({ formatter: jsonLinesFormatter })
+```
+
+**Recommendation**: Use `getConsoleSink()` on Bun. The stream sink's manual wrapping isn't worth it unless you need specific stream behavior.
+
+---
+
+## 11. When NOT to Use LogTape
+
+### 11.1 Simple Scripts
+
+If your CLI is a single-file script with one code path:
+
+```typescript
+#!/usr/bin/env bun
+const result = await fetch(url);
+console.log(JSON.stringify(result));
+```
+
+Just use `console.error()` for debug messages. LogTape adds complexity without proportional value.
+
+### 11.2 No Async Orchestration
+
+If your CLI doesn't do parallel async work (no `Promise.all()`, no concurrent API calls), LogTape's context propagation -- its biggest CLI feature -- provides no benefit over simple `console.error("[reddit]", message)` prefixing.
+
+### 11.3 Bundle Size is Sacred
+
+LogTape is 5.3 KB min+gz -- small, but not zero. If your CLI has zero runtime dependencies and you want to keep it that way, the cost is a non-zero dependency for a debugging convenience.
+
+### 11.4 You Don't Debug in Production
+
+If your CLI is a personal tool that you only debug by reading source code, structured logging is overhead. It earns its keep when:
+- Other people use your CLI
+- AI agents call your CLI
+- Failures happen in environments you can't reproduce
+
+### 11.5 Decision Checklist
+
+Add LogTape if **2+ are true**:
+
+- [ ] CLI orchestrates parallel async operations
+- [ ] CLI is called by AI agents as a subprocess
+- [ ] CLI has multiple failure modes (rate limits, cache, API errors)
+- [ ] CLI is distributed to other users
+- [ ] You need per-module verbosity control
+- [ ] You want structured diagnostics without parsing human-readable output
+
+---
+
+## 12. Migration Guide
+
+### 12.1 Phase 1: Foundation (~30 minutes)
+
+Add LogTape, create the configuration module, wire it into the CLI entry point. Replace existing `[debug]` stderr writes with logger calls.
+
+**Before**:
+```typescript
+if (args.debug) {
+  process.stderr.write(`[debug] query-type=${resolvedQueryType}\n`);
+}
+```
+
+**After**:
+```typescript
+logger.debug("Query type resolved: {queryType}", {
+  queryType: resolvedQueryType,
+});
+```
+
+The `--debug` flag now controls LogTape's level instead of guarding individual writes.
+
+### 12.2 Phase 2: Async Context (~1 hour)
+
+Wrap each `Promise.all()` branch with `withContext()`. Add cache hit/miss logging in the cache module.
+
+### 12.3 Phase 3: Fingers Crossed (~30 minutes)
+
+Add the `fingersCrossed` sink so failures automatically dump the debug trace. This eliminates the need for users to re-run with `--debug` after a failure.
+
+### 12.4 Phase 4: Ecosystem (optional, as needed)
+
+| Need | Package | Effort |
+|------|---------|--------|
+| Rotating log files | `@logtape/file` | ~30 min |
+| OpenTelemetry export | `logtape-otel` | ~1 hour |
+| Sentry error tracking | `@logtape/sentry` | ~1 hour |
+| Config-from-file | `@logtape/config` | ~30 min |
+| PII redaction | `@logtape/redaction` | ~30 min |
+
+### 12.5 What to Keep
+
+- **`ProgressDisplay`** -- LogTape is not a progress UI. Keep your spinners.
+- **`console.log()` for program output** -- LogTape handles diagnostics, not program output.
+- **Exit codes** -- LogTape doesn't replace `process.exit()` semantics.
+- **`--quiet` flag** -- Map it to `lowestLevel: "error"`.
+
+---
+
+## 13. Performance
+
+### 13.1 Benchmarks on Bun
+
+From LogTape's official comparison (logtape.org/comparison):
+
+**Console logging (nanoseconds per iteration on Bun)**:
+
+| Library | Bun (ns) | Relative |
+|---------|----------|----------|
+| LogTape | 225 | 1.0x (baseline) |
+| Pino | 874 | 3.9x slower |
+| Winston | 1,770 | 7.9x slower |
+| Bunyan | 2,020 | 9.0x slower |
+| Signale | 2,110 | 9.4x slower |
+| log4js | 3,540 | 15.7x slower |
+
+**Null benchmark (disabled logging, Bun)**:
+
+| Library | Bun (ns) |
+|---------|----------|
+| LogTape | 187 |
+| log4js | 261 |
+| Winston | 569 |
+| Pino | 715 |
+
+**What this means for CLIs**: A typical wots run logs ~20-50 messages. At 225ns each, that's ~11 microseconds total -- invisible. Even at debug level with hundreds of messages, logging adds < 1ms to a CLI that runs for 5-30 seconds.
+
+### 13.2 No-Op Overhead
+
+When LogTape is imported but `configure()` is never called (the library consumer case), the no-op cost is ~187ns per log call on Bun. For a library that logs 100 times during a function call, that's ~19 microseconds of overhead -- effectively zero.
+
+### 13.3 Context Propagation Cost
+
+`withContext()` uses `AsyncLocalStorage`, which adds ~200-500ns per async operation on Bun. For `Promise.all()` with 3-4 branches, this is < 2 microseconds total.
+
+### 13.4 When Performance Matters
+
+The only scenario where logging overhead is measurable is inside tight scoring loops:
+
+```typescript
+// DON'T log inside the scoring loop (50+ items * multiple factors):
+for (const item of items) {
+  logger.trace("Scoring item: {id}", { id: item.id });  // Thousands of calls
+  item.score = computeScore(item);
+}
+
+// DO log the result:
+logger.debug("Scoring complete: top={topScore}, median={median}, count={count}", {
+  topScore: items[0].score,
+  median: items[Math.floor(items.length / 2)].score,
+  count: items.length,
+});
+```
+
+---
+
+## 14. Comparison Matrix
+
+### 14.1 Full Feature Comparison
+
+| Feature | LogTape | Pino | Winston | Console |
+|---------|---------|------|---------|---------|
+| **Bundle (min+gz)** | 5.3 KB | 3.1 KB | 38.3 KB | 0 KB |
+| **Dependencies** | 0 | 1 | 17 | 0 |
+| **Bun support** | Full | Limited | Limited | Full |
+| **No-op default** | Yes | No | No | N/A |
+| **Structured logging** | Yes | Yes | Yes | No |
+| **Async context** | Built-in | Manual child() | Manual child() | No |
+| **Human formatter** | Built-in | pino-pretty (dev dep) | Built-in | Built-in |
+| **JSON formatter** | Built-in | Default | Built-in | No |
+| **Tree-shakable** | Yes | No | No | N/A |
+| **Hierarchical categories** | Yes | No (flat) | No (flat) | No |
+| **Fingers crossed** | Built-in | No | No | No |
+| **Config from file** | @logtape/config | pino.transport() | Built-in | No |
+| **Lazy evaluation** | Built-in | No | No | No |
+| **Template literals** | Yes | No | No | No |
+| **OTel integration** | logtape-otel | pino-opentelemetry | winston-otel | No |
+| **Sentry integration** | @logtape/sentry | @sentry/node | @sentry/node | No |
+| **Pino bridge** | @logtape/adaptor-pino | N/A | N/A | No |
+| **Edge runtime** | Yes | No | No | Yes |
+
+### 14.2 When to Pick Each
+
+| Choose | When |
+|--------|------|
+| **LogTape** | Bun CLI, library-first design needed, async context, zero deps |
+| **Pino** | Node.js backend migrating to Bun, existing Pino infrastructure |
+| **Winston** | Legacy Node.js app, need built-in transports, don't care about bundle |
+| **Console** | Single-file script, no structured logging needed |
+
+---
+
+## 15. Decision Framework
+
+### 15.1 For wots Specifically
+
+| Factor | Assessment |
+|--------|-----------|
+| Parallel async orchestration | Yes -- Reddit, X, YouTube, web in `Promise.all()` |
+| Called by AI agents | Yes -- Beat Reporter sub-agents via `bunx` |
+| Multiple failure modes | Yes -- rate limits, stale cache, API errors, yt-dlp failures |
+| Distributed to users | Yes -- published on npm |
+| Library export | Yes -- `src/index.ts` barrel for programmatic use |
+| Current debug pattern | Manual `[debug]` stderr writes guarded by flag |
+
+**Verdict**: LogTape is a clear fit. All six checklist items are true.
+
+### 15.2 For Any Bun CLI Tool
+
+```
+Is your CLI a single-file script with one code path?
+  → Yes: Use console.error(). Stop here.
+  → No: Continue.
+
+Does your CLI orchestrate parallel async work?
+  → Yes: LogTape's withContext() is high-value.
+  → No: LogTape still works, but the context feature is wasted.
+
+Is your CLI called by AI agents or other machines?
+  → Yes: JSON Lines on stderr is essential. LogTape provides this.
+  → No: Human-readable stderr may be sufficient.
+
+Do you export a library alongside the CLI?
+  → Yes: LogTape's no-op default is critical.
+  → No: Any logging library works.
+
+How many runtime dependencies does your CLI have?
+  → Zero: Adding LogTape (5.3 KB, 0 deps) is a small cost.
+  → Many: One more dependency is irrelevant. Pick the best tool.
+```
+
+---
+
+## 16. Resources
+
+### 16.1 Official Documentation
+
+- [LogTape Home](https://logtape.org/) -- main documentation site
+- [Quick Start](https://logtape.org/manual/start) -- installation and basic setup
+- [Configuration](https://logtape.org/manual/config) -- full `configure()` reference
+- [Categories](https://logtape.org/manual/categories) -- hierarchical logger design
+- [Sinks](https://logtape.org/manual/sinks) -- all sink types and custom sinks
+- [Formatters](https://logtape.org/manual/formatters) -- text, ANSI, JSON Lines, Pretty
+- [Contexts](https://logtape.org/manual/contexts) -- explicit, implicit, lazy contexts
+- [Library Authors](https://logtape.org/manual/library) -- guide for library-first design
+- [Testing](https://logtape.org/manual/testing) -- reset, buffer sinks, test isolation
+- [Comparison](https://logtape.org/comparison) -- benchmarks and feature matrix vs alternatives
+
+### 16.2 Ecosystem Packages
+
+| Package | Purpose | Docs |
+|---------|---------|------|
+| [@logtape/file](https://logtape.org/sinks/file) | File + rotating file sinks | logtape.org |
+| [logtape-otel](https://github.com/dahlia/logtape-otel) | OpenTelemetry sink | GitHub |
+| [@logtape/sentry](https://logtape.org/sinks/sentry) | Sentry error tracking | logtape.org |
+| [@logtape/config](https://logtape.org/manual/config) | Config from JSON/YAML/TOML | logtape.org |
+| [@logtape/redaction](https://logtape.org/manual/formatters) | Pattern-based PII masking | logtape.org |
+| [@logtape/pretty](https://logtape.org/manual/formatters) | Emoji-rich dev formatter | logtape.org |
+| [@logtape/adaptor-pino](https://github.com/dahlia/logtape) | Bridge to Pino infrastructure | GitHub |
+| [@logtape/cloudwatch-logs](https://logtape.org/sinks/cloudwatch-logs) | AWS CloudWatch | logtape.org |
+
+### 16.3 Community Resources
+
+- [Logging in Node.js/Deno/Bun 2026](https://hackers.pub/@hongminhee/2026/logging-nodejs-deno-bun-2026) -- author's comprehensive guide (hackers.pub)
+- [Trace-Connected Structured Logging with LogTape and Sentry](https://blog.sentry.io/trace-connected-structured-logging-with-logtape-and-sentry/) -- Sentry's official integration guide
+- [Fedify Case Study](https://hackers.pub/@hongminhee/2025/logtape-fedify-case-study) -- the origin story and library-first design rationale
+- [LogTape GitHub](https://github.com/dahlia/logtape) -- source, issues, discussions
+- [LogTape on JSR](https://jsr.io/@logtape/logtape) -- Deno/JSR registry
+- [Better Stack: Top 8 Node.js Logging Libraries](https://betterstack.com/community/guides/logging/best-nodejs-logging-libraries/) -- broader ecosystem context
+- [Show HN: Universal Logger for Node/Deno/Bun](https://news.ycombinator.com/item?id=41557107) -- Hacker News discussion
+
+### 16.4 Related X Posts
+
+- [@hongminhee: LogTape 2.0.0 release](https://x.com/hongminhee/status/2011717024276496444) -- v2 features: lazy(), JSON config, async lazy eval
+- [@hongminhee: Optique 0.8.0 CLI integration](https://x.com/hongminhee/status/1998253989264249272) -- LogTape config via CLI args
+- [@TechSquidTV: "For you AND your AI"](https://x.com/TechSquidTV/status/2021999136539804061) -- AI agent log consumption pattern
+- [@zeeg (Sentry CEO): using LogTape](https://x.com/zeeg/status/2009028094993289653) -- Sentry CEO adoption signal
+
+---
+
+## 17. Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Category** | A string array (e.g., `["wots", "search", "reddit"]`) that namespaces a logger. Forms a hierarchy where logs propagate upward to parent categories. |
+| **Sink** | A function that receives log records and writes them somewhere (console, file, network). Signature: `(record: LogRecord) => void`. |
+| **Formatter** | A function that converts a `LogRecord` into a string for text-based sinks. Examples: text, ANSI color, JSON Lines. |
+| **Explicit context** | Key-value pairs attached to a logger instance via `.with()`. Inherited by child loggers. |
+| **Implicit context** | Key-value pairs set via `withContext()` that propagate through the entire async call tree via `AsyncLocalStorage`. |
+| **Lazy context** | Context values wrapped in `lazy(() => value)` that evaluate at log time, not at `.with()` time. |
+| **Fingers crossed** | A sink wrapper that buffers low-severity logs and flushes the entire buffer when a high-severity event occurs. Named after the Monolog (PHP) pattern. |
+| **No-op default** | LogTape's behavior when `configure()` has not been called: all log calls silently return without side effects. Zero output, zero overhead beyond the function call. |
+| **Library-first** | Design philosophy where the logging library assumes it will be used inside other libraries, not just applications. The library never calls `configure()` -- the consuming application does. |
+| **JSON Lines** | Newline-delimited JSON format where each line is a complete JSON object. Standard format for machine-readable structured logs. |
+| **Category prefix** | A `withCategoryPrefix()` call that prepends a namespace to all logger categories within an async scope. Used by SDKs wrapping internal libraries. |
+| **Buffer sink** | A testing pattern where logs are pushed to an in-memory array for assertion: `buffer.push.bind(buffer)`. |
+| **Tri-modal output** | A CLI pattern with three output modes: human-readable (compact), machine-readable (JSON envelope), and streaming (JSONL). Each serves a different consumer. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,6 +174,7 @@ interface SearchTaskResult {
 	rateLimitType: 'transient' | 'quota' | null
 	rateLimitErrorCode: string | null
 	rateLimitResetMs: number | null
+	rateLimitRetryAfterMs: number | null
 	rateLimitRetries: number | null
 }
 
@@ -182,11 +183,13 @@ const NO_RATE_LIMIT: Pick<
 	| 'rateLimitType'
 	| 'rateLimitErrorCode'
 	| 'rateLimitResetMs'
+	| 'rateLimitRetryAfterMs'
 	| 'rateLimitRetries'
 > = {
 	rateLimitType: null,
 	rateLimitErrorCode: null,
 	rateLimitResetMs: null,
+	rateLimitRetryAfterMs: null,
 	rateLimitRetries: null,
 }
 
@@ -281,6 +284,7 @@ async function searchRedditTask(
 	let rateLimitType: 'transient' | 'quota' | null = null
 	let rateLimitErrorCode: string | null = null
 	let rateLimitResetMs: number | null = null
+	let rateLimitRetryAfterMs: number | null = null
 	let rateLimitRetries: number | null = null
 
 	try {
@@ -303,6 +307,7 @@ async function searchRedditTask(
 			rateLimitType = e.retryable ? 'transient' : 'quota'
 			rateLimitErrorCode = e.error_code
 			rateLimitResetMs = e.ratelimit_reset_ms
+			rateLimitRetryAfterMs = e.retry_after_ms
 			rateLimitRetries = e.retries_attempted
 			error = e.retryable
 				? `Rate limited after ${e.retries_attempted} retries`
@@ -325,6 +330,7 @@ async function searchRedditTask(
 						rateLimitType,
 						rateLimitErrorCode,
 						rateLimitResetMs,
+						rateLimitRetryAfterMs,
 						rateLimitRetries,
 					}
 				}
@@ -413,6 +419,7 @@ async function searchRedditTask(
 		rateLimitType,
 		rateLimitErrorCode,
 		rateLimitResetMs,
+		rateLimitRetryAfterMs,
 		rateLimitRetries,
 	}
 }
@@ -487,6 +494,7 @@ async function searchXTask(
 	let rateLimitType: 'transient' | 'quota' | null = null
 	let rateLimitErrorCode: string | null = null
 	let rateLimitResetMs: number | null = null
+	let rateLimitRetryAfterMs: number | null = null
 	let rateLimitRetries: number | null = null
 
 	try {
@@ -509,6 +517,7 @@ async function searchXTask(
 			rateLimitType = e.retryable ? 'transient' : 'quota'
 			rateLimitErrorCode = e.error_code
 			rateLimitResetMs = e.ratelimit_reset_ms
+			rateLimitRetryAfterMs = e.retry_after_ms
 			rateLimitRetries = e.retries_attempted
 			error = e.retryable
 				? `Rate limited after ${e.retries_attempted} retries`
@@ -531,6 +540,7 @@ async function searchXTask(
 						rateLimitType,
 						rateLimitErrorCode,
 						rateLimitResetMs,
+						rateLimitRetryAfterMs,
 						rateLimitRetries,
 					}
 				}
@@ -560,6 +570,7 @@ async function searchXTask(
 		rateLimitType,
 		rateLimitErrorCode,
 		rateLimitResetMs,
+		rateLimitRetryAfterMs,
 		rateLimitRetries,
 	}
 }
@@ -1249,10 +1260,14 @@ async function main() {
 		taskResults.reddit?.rateLimitErrorCode ?? null
 	report.reddit_rate_limit_reset_ms =
 		taskResults.reddit?.rateLimitResetMs ?? null
+	report.reddit_rate_limit_retry_after_ms =
+		taskResults.reddit?.rateLimitRetryAfterMs ?? null
 	report.reddit_used_stale_cache = taskResults.reddit?.usedStaleCache ?? false
 	report.x_rate_limit_type = taskResults.x?.rateLimitType ?? null
 	report.x_rate_limit_error_code = taskResults.x?.rateLimitErrorCode ?? null
 	report.x_rate_limit_reset_ms = taskResults.x?.rateLimitResetMs ?? null
+	report.x_rate_limit_retry_after_ms =
+		taskResults.x?.rateLimitRetryAfterMs ?? null
 	report.x_used_stale_cache = taskResults.x?.usedStaleCache ?? false
 	report.from_cache = anyFromCache
 	report.cache_age_hours = maxCacheAge

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,23 @@ interface SearchTaskResult {
 	cacheAgeHours: number | null
 	rateLimited: boolean
 	usedStaleCache: boolean
+	rateLimitType: 'transient' | 'quota' | null
+	rateLimitErrorCode: string | null
+	rateLimitResetMs: number | null
+	rateLimitRetries: number | null
+}
+
+const NO_RATE_LIMIT: Pick<
+	SearchTaskResult,
+	| 'rateLimitType'
+	| 'rateLimitErrorCode'
+	| 'rateLimitResetMs'
+	| 'rateLimitRetries'
+> = {
+	rateLimitType: null,
+	rateLimitErrorCode: null,
+	rateLimitResetMs: null,
+	rateLimitRetries: null,
 }
 
 interface CachedSearchPayload {
@@ -229,6 +246,7 @@ async function searchRedditTask(
 				cacheAgeHours: ageHours,
 				rateLimited: false,
 				usedStaleCache: false,
+				...NO_RATE_LIMIT,
 			}
 		}
 	}
@@ -251,6 +269,7 @@ async function searchRedditTask(
 					cacheAgeHours: ageHours,
 					rateLimited: false,
 					usedStaleCache: false,
+					...NO_RATE_LIMIT,
 				}
 			}
 		}
@@ -259,6 +278,10 @@ async function searchRedditTask(
 	let raw: Record<string, unknown> | null = null
 	let error: string | null = null
 	let rateLimited = false
+	let rateLimitType: 'transient' | 'quota' | null = null
+	let rateLimitErrorCode: string | null = null
+	let rateLimitResetMs: number | null = null
+	let rateLimitRetries: number | null = null
 
 	try {
 		if (mock) {
@@ -277,6 +300,10 @@ async function searchRedditTask(
 		raw = { error: String(e) }
 		if (e instanceof RateLimitError) {
 			rateLimited = true
+			rateLimitType = e.retryable ? 'transient' : 'quota'
+			rateLimitErrorCode = e.error_code
+			rateLimitResetMs = e.ratelimit_reset_ms
+			rateLimitRetries = e.retries_attempted
 			error = e.retryable
 				? `Rate limited after ${e.retries_attempted} retries`
 				: 'OpenAI quota/billing limit reached (non-retryable 429)'
@@ -295,6 +322,10 @@ async function searchRedditTask(
 						cacheAgeHours: staleAge,
 						rateLimited: true,
 						usedStaleCache: true,
+						rateLimitType,
+						rateLimitErrorCode,
+						rateLimitResetMs,
+						rateLimitRetries,
 					}
 				}
 			}
@@ -379,6 +410,10 @@ async function searchRedditTask(
 		cacheAgeHours: null,
 		rateLimited,
 		usedStaleCache: false,
+		rateLimitType,
+		rateLimitErrorCode,
+		rateLimitResetMs,
+		rateLimitRetries,
 	}
 }
 
@@ -417,6 +452,7 @@ async function searchXTask(
 				cacheAgeHours: ageHours,
 				rateLimited: false,
 				usedStaleCache: false,
+				...NO_RATE_LIMIT,
 			}
 		}
 	}
@@ -439,6 +475,7 @@ async function searchXTask(
 					cacheAgeHours: ageHours,
 					rateLimited: false,
 					usedStaleCache: false,
+					...NO_RATE_LIMIT,
 				}
 			}
 		}
@@ -447,6 +484,10 @@ async function searchXTask(
 	let raw: Record<string, unknown> | null = null
 	let error: string | null = null
 	let rateLimited = false
+	let rateLimitType: 'transient' | 'quota' | null = null
+	let rateLimitErrorCode: string | null = null
+	let rateLimitResetMs: number | null = null
+	let rateLimitRetries: number | null = null
 
 	try {
 		if (mock) {
@@ -465,6 +506,10 @@ async function searchXTask(
 		raw = { error: String(e) }
 		if (e instanceof RateLimitError) {
 			rateLimited = true
+			rateLimitType = e.retryable ? 'transient' : 'quota'
+			rateLimitErrorCode = e.error_code
+			rateLimitResetMs = e.ratelimit_reset_ms
+			rateLimitRetries = e.retries_attempted
 			error = e.retryable
 				? `Rate limited after ${e.retries_attempted} retries`
 				: 'xAI quota/billing limit reached (non-retryable 429)'
@@ -483,6 +528,10 @@ async function searchXTask(
 						cacheAgeHours: staleAge,
 						rateLimited: true,
 						usedStaleCache: true,
+						rateLimitType,
+						rateLimitErrorCode,
+						rateLimitResetMs,
+						rateLimitRetries,
 					}
 				}
 			}
@@ -508,6 +557,10 @@ async function searchXTask(
 		cacheAgeHours: null,
 		rateLimited,
 		usedStaleCache: false,
+		rateLimitType,
+		rateLimitErrorCode,
+		rateLimitResetMs,
+		rateLimitRetries,
 	}
 }
 
@@ -918,6 +971,10 @@ async function main() {
 	let xRateLimited = false
 	let redditUsedStaleCache = false
 	let xUsedStaleCache = false
+	const taskResults: {
+		reddit: SearchTaskResult | null
+		x: SearchTaskResult | null
+	} = { reddit: null, x: null }
 
 	const promises: Promise<void>[] = []
 
@@ -935,6 +992,7 @@ async function main() {
 				args.mock,
 				cacheOpts,
 			).then((result) => {
+				taskResults.reddit = result
 				redditItems = result.items
 				rawOpenai = result.raw
 				redditError = result.error
@@ -973,6 +1031,7 @@ async function main() {
 				args.mock,
 				cacheOpts,
 			).then((result) => {
+				taskResults.x = result
 				xItems = result.items
 				rawXai = result.raw
 				xError = result.error
@@ -1185,6 +1244,16 @@ async function main() {
 	report.reddit_error = redditError
 	report.x_error = xError
 	report.youtube_error = youtubeError
+	report.reddit_rate_limit_type = taskResults.reddit?.rateLimitType ?? null
+	report.reddit_rate_limit_error_code =
+		taskResults.reddit?.rateLimitErrorCode ?? null
+	report.reddit_rate_limit_reset_ms =
+		taskResults.reddit?.rateLimitResetMs ?? null
+	report.reddit_used_stale_cache = taskResults.reddit?.usedStaleCache ?? false
+	report.x_rate_limit_type = taskResults.x?.rateLimitType ?? null
+	report.x_rate_limit_error_code = taskResults.x?.rateLimitErrorCode ?? null
+	report.x_rate_limit_reset_ms = taskResults.x?.rateLimitResetMs ?? null
+	report.x_used_stale_cache = taskResults.x?.usedStaleCache ?? false
 	report.from_cache = anyFromCache
 	report.cache_age_hours = maxCacheAge
 	report.context_snippet_md = renderContextSnippet(report)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1262,12 +1262,16 @@ async function main() {
 		taskResults.reddit?.rateLimitResetMs ?? null
 	report.reddit_rate_limit_retry_after_ms =
 		taskResults.reddit?.rateLimitRetryAfterMs ?? null
+	report.reddit_rate_limit_retries_attempted =
+		taskResults.reddit?.rateLimitRetries ?? null
 	report.reddit_used_stale_cache = taskResults.reddit?.usedStaleCache ?? false
 	report.x_rate_limit_type = taskResults.x?.rateLimitType ?? null
 	report.x_rate_limit_error_code = taskResults.x?.rateLimitErrorCode ?? null
 	report.x_rate_limit_reset_ms = taskResults.x?.rateLimitResetMs ?? null
 	report.x_rate_limit_retry_after_ms =
 		taskResults.x?.rateLimitRetryAfterMs ?? null
+	report.x_rate_limit_retries_attempted =
+		taskResults.x?.rateLimitRetries ?? null
 	report.x_used_stale_cache = taskResults.x?.usedStaleCache ?? false
 	report.from_cache = anyFromCache
 	report.cache_age_hours = maxCacheAge

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1265,6 +1265,7 @@ async function main() {
 	report.reddit_rate_limit_retries_attempted =
 		taskResults.reddit?.rateLimitRetries ?? null
 	report.reddit_used_stale_cache = taskResults.reddit?.usedStaleCache ?? false
+	report.reddit_cache_age_hours = taskResults.reddit?.cacheAgeHours ?? null
 	report.x_rate_limit_type = taskResults.x?.rateLimitType ?? null
 	report.x_rate_limit_error_code = taskResults.x?.rateLimitErrorCode ?? null
 	report.x_rate_limit_reset_ms = taskResults.x?.rateLimitResetMs ?? null
@@ -1273,6 +1274,7 @@ async function main() {
 	report.x_rate_limit_retries_attempted =
 		taskResults.x?.rateLimitRetries ?? null
 	report.x_used_stale_cache = taskResults.x?.usedStaleCache ?? false
+	report.x_cache_age_hours = taskResults.x?.cacheAgeHours ?? null
 	report.from_cache = anyFromCache
 	report.cache_age_hours = maxCacheAge
 	report.context_snippet_md = renderContextSnippet(report)

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -128,19 +128,30 @@ function renderRateLimitBlock(
 		source === 'reddit'
 			? report.reddit_rate_limit_retry_after_ms
 			: report.x_rate_limit_retry_after_ms
+	const retriesAttempted =
+		source === 'reddit'
+			? report.reddit_rate_limit_retries_attempted
+			: report.x_rate_limit_retries_attempted
 	const usedStale =
 		source === 'reddit'
 			? report.reddit_used_stale_cache
 			: report.x_used_stale_cache
 
 	const lines: string[] = []
-	lines.push(`**${source}_status:** rate_limited`)
 	lines.push(`**${source}_rate_limit_type:** ${type}`)
-	if (errorCode) lines.push(`**${source}_error_code:** ${errorCode}`)
+	if (errorCode) {
+		const sanitizedErrorCode = errorCode.replace(/[\n\r\t]/g, ' ').slice(0, 100)
+		lines.push(`**${source}_rate_limit_error_code:** ${sanitizedErrorCode}`)
+	}
 	const resetStr = formatResetTime(resetMs)
 	if (resetStr) lines.push(`**${source}_rate_limit_reset:** ${resetStr}`)
 	const retryAfterStr = formatResetTime(retryAfterMs)
-	if (retryAfterStr) lines.push(`**${source}_retry_after:** ${retryAfterStr}`)
+	if (retryAfterStr)
+		lines.push(`**${source}_rate_limit_retry_after:** ${retryAfterStr}`)
+	if (retriesAttempted != null)
+		lines.push(
+			`**${source}_rate_limit_retries_attempted:** ${retriesAttempted}`,
+		)
 	if (usedStale) {
 		const ageStr = report.cache_age_hours
 			? `age: ${report.cache_age_hours.toFixed(1)}h`

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -95,6 +95,57 @@ function trendBadge(trendScore?: number): string {
 	return ` [trend:${trendScore}]`
 }
 
+/** Format milliseconds into a human-readable reset time (e.g. "45s", "2m30s"). */
+function formatResetTime(ms: number | null): string | null {
+	if (ms == null || ms <= 0) return null
+	const totalSec = Math.ceil(ms / 1000)
+	if (totalSec < 60) return `${totalSec}s`
+	const min = Math.floor(totalSec / 60)
+	const sec = totalSec % 60
+	return sec > 0 ? `${min}m${sec}s` : `${min}m`
+}
+
+/** Render structured rate-limit diagnostics for a source. */
+function renderRateLimitBlock(
+	source: 'reddit' | 'x',
+	report: Report,
+): string[] | null {
+	const type =
+		source === 'reddit'
+			? report.reddit_rate_limit_type
+			: report.x_rate_limit_type
+	if (!type) return null
+
+	const errorCode =
+		source === 'reddit'
+			? report.reddit_rate_limit_error_code
+			: report.x_rate_limit_error_code
+	const resetMs =
+		source === 'reddit'
+			? report.reddit_rate_limit_reset_ms
+			: report.x_rate_limit_reset_ms
+	const usedStale =
+		source === 'reddit'
+			? report.reddit_used_stale_cache
+			: report.x_used_stale_cache
+
+	const lines: string[] = []
+	lines.push(`**${source}_status:** rate_limited`)
+	lines.push(`**${source}_rate_limit_type:** ${type}`)
+	if (errorCode) lines.push(`**${source}_error_code:** ${errorCode}`)
+	const resetStr = formatResetTime(resetMs)
+	if (resetStr) lines.push(`**${source}_rate_limit_reset:** ${resetStr}`)
+	if (usedStale) {
+		const ageStr = report.cache_age_hours
+			? `age: ${report.cache_age_hours.toFixed(1)}h`
+			: ''
+		lines.push(
+			`**${source}_fallback:** stale_cache${ageStr ? ` (${ageStr})` : ''}`,
+		)
+	}
+	return lines
+}
+
 /** Render compact output for Claude to synthesize. */
 export function renderCompact(
 	report: Report,
@@ -168,12 +219,17 @@ export function renderCompact(
 
 	// Reddit items
 	if (report.reddit_error) {
-		lines.push(
-			'### Reddit Threads',
-			'',
-			`**ERROR:** ${report.reddit_error}`,
-			'',
-		)
+		const rlBlock = renderRateLimitBlock('reddit', report)
+		if (rlBlock) {
+			lines.push('### Reddit Threads', '', ...rlBlock, '')
+		} else {
+			lines.push(
+				'### Reddit Threads',
+				'',
+				`**ERROR:** ${report.reddit_error}`,
+				'',
+			)
+		}
 	} else if (
 		['both', 'reddit-only'].includes(report.mode) &&
 		report.reddit.length === 0
@@ -221,7 +277,12 @@ export function renderCompact(
 
 	// X items
 	if (report.x_error) {
-		lines.push('### X Posts', '', `**ERROR:** ${report.x_error}`, '')
+		const rlBlock = renderRateLimitBlock('x', report)
+		if (rlBlock) {
+			lines.push('### X Posts', '', ...rlBlock, '')
+		} else {
+			lines.push('### X Posts', '', `**ERROR:** ${report.x_error}`, '')
+		}
 	} else if (
 		['both', 'x-only', 'all', 'x-web'].includes(report.mode) &&
 		report.x.length === 0

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -136,6 +136,10 @@ function renderRateLimitBlock(
 		source === 'reddit'
 			? report.reddit_used_stale_cache
 			: report.x_used_stale_cache
+	const cacheAgeHours =
+		source === 'reddit'
+			? report.reddit_cache_age_hours
+			: report.x_cache_age_hours
 
 	const lines: string[] = []
 	lines.push(`**${source}_rate_limit_type:** ${type}`)
@@ -153,9 +157,8 @@ function renderRateLimitBlock(
 			`**${source}_rate_limit_retries_attempted:** ${retriesAttempted}`,
 		)
 	if (usedStale) {
-		const ageStr = report.cache_age_hours
-			? `age: ${report.cache_age_hours.toFixed(1)}h`
-			: ''
+		const ageStr =
+			cacheAgeHours != null ? `age: ${cacheAgeHours.toFixed(1)}h` : ''
 		lines.push(
 			`**${source}_fallback:** stale_cache${ageStr ? ` (${ageStr})` : ''}`,
 		)

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -124,6 +124,10 @@ function renderRateLimitBlock(
 		source === 'reddit'
 			? report.reddit_rate_limit_reset_ms
 			: report.x_rate_limit_reset_ms
+	const retryAfterMs =
+		source === 'reddit'
+			? report.reddit_rate_limit_retry_after_ms
+			: report.x_rate_limit_retry_after_ms
 	const usedStale =
 		source === 'reddit'
 			? report.reddit_used_stale_cache
@@ -135,6 +139,8 @@ function renderRateLimitBlock(
 	if (errorCode) lines.push(`**${source}_error_code:** ${errorCode}`)
 	const resetStr = formatResetTime(resetMs)
 	if (resetStr) lines.push(`**${source}_rate_limit_reset:** ${resetStr}`)
+	const retryAfterStr = formatResetTime(retryAfterMs)
+	if (retryAfterStr) lines.push(`**${source}_retry_after:** ${retryAfterStr}`)
 	if (usedStale) {
 		const ageStr = report.cache_age_hours
 			? `age: ${report.cache_age_hours.toFixed(1)}h`

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -113,7 +113,11 @@ function renderRateLimitBlock(
 	const lines: string[] = []
 	lines.push(`**${source}_rate_limit_type:** ${type}`)
 	if (errorCode) {
-		const sanitizedErrorCode = errorCode.replace(/[\n\r\t]/g, ' ').slice(0, 100)
+		const sanitizedErrorCode = errorCode
+			.replace(/\p{Cc}/gu, ' ')
+			.replace(/\s+/g, ' ')
+			.trim()
+			.slice(0, 100)
 		lines.push(`**${source}_rate_limit_error_code:** ${sanitizedErrorCode}`)
 	}
 	const resetStr = formatResetTime(resetMs)

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -43,37 +43,6 @@ function assessDataFreshness(report: Report) {
 	}
 }
 
-function summarizeFreshness(report: Report) {
-	const items = [
-		...report.reddit,
-		...report.x,
-		...report.web,
-		...report.youtube,
-	]
-	let dated = 0
-	let fresh72h = 0
-	let fresh7d = 0
-
-	for (const item of items) {
-		const age = daysAgo(item.date)
-		if (age == null) continue
-		dated += 1
-		if (age <= 3) fresh72h += 1
-		if (age <= 7) fresh7d += 1
-	}
-
-	const pct = (value: number) =>
-		dated > 0 ? Math.round((value / dated) * 100) : 0
-
-	return {
-		dated,
-		fresh72h,
-		fresh7d,
-		fresh72hPct: pct(fresh72h),
-		fresh7dPct: pct(fresh7d),
-	}
-}
-
 function recencyBadge(date: string | null): string {
 	const age = daysAgo(date)
 	if (age == null) return ''

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -131,12 +131,14 @@ export interface Report {
 	reddit_rate_limit_retry_after_ms: number | null
 	reddit_rate_limit_retries_attempted: number | null
 	reddit_used_stale_cache: boolean
+	reddit_cache_age_hours: number | null
 	x_rate_limit_type: 'transient' | 'quota' | null
 	x_rate_limit_error_code: string | null
 	x_rate_limit_reset_ms: number | null
 	x_rate_limit_retry_after_ms: number | null
 	x_rate_limit_retries_attempted: number | null
 	x_used_stale_cache: boolean
+	x_cache_age_hours: number | null
 	from_cache: boolean
 	cache_age_hours: number | null
 }
@@ -199,6 +201,8 @@ export function reportToDict(report: Report): Record<string, unknown> {
 			report.reddit_rate_limit_retries_attempted
 	if (report.reddit_used_stale_cache)
 		d.reddit_used_stale_cache = report.reddit_used_stale_cache
+	if (report.reddit_cache_age_hours != null)
+		d.reddit_cache_age_hours = report.reddit_cache_age_hours
 	if (report.x_rate_limit_type) d.x_rate_limit_type = report.x_rate_limit_type
 	if (report.x_rate_limit_error_code)
 		d.x_rate_limit_error_code = report.x_rate_limit_error_code
@@ -210,6 +214,8 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.x_rate_limit_retries_attempted = report.x_rate_limit_retries_attempted
 	if (report.x_used_stale_cache)
 		d.x_used_stale_cache = report.x_used_stale_cache
+	if (report.x_cache_age_hours != null)
+		d.x_cache_age_hours = report.x_cache_age_hours
 	if (report.from_cache) d.from_cache = report.from_cache
 	if (report.cache_age_hours != null) d.cache_age_hours = report.cache_age_hours
 	return d
@@ -346,12 +352,14 @@ export function createReport(
 		reddit_rate_limit_retry_after_ms: null,
 		reddit_rate_limit_retries_attempted: null,
 		reddit_used_stale_cache: false,
+		reddit_cache_age_hours: null,
 		x_rate_limit_type: null,
 		x_rate_limit_error_code: null,
 		x_rate_limit_reset_ms: null,
 		x_rate_limit_retry_after_ms: null,
 		x_rate_limit_retries_attempted: null,
 		x_used_stale_cache: false,
+		x_cache_age_hours: null,
 		from_cache: false,
 		cache_age_hours: null,
 	}
@@ -478,6 +486,8 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.reddit_rate_limit_retries_attempted as number | null) ?? null,
 		reddit_used_stale_cache:
 			(data.reddit_used_stale_cache as boolean | undefined) ?? false,
+		reddit_cache_age_hours:
+			(data.reddit_cache_age_hours as number | null) ?? null,
 		x_rate_limit_type:
 			(data.x_rate_limit_type as 'transient' | 'quota' | null) ?? null,
 		x_rate_limit_error_code:
@@ -490,6 +500,7 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.x_rate_limit_retries_attempted as number | null) ?? null,
 		x_used_stale_cache:
 			(data.x_used_stale_cache as boolean | undefined) ?? false,
+		x_cache_age_hours: (data.x_cache_age_hours as number | null) ?? null,
 		from_cache: (data.from_cache as boolean | undefined) ?? false,
 		cache_age_hours: (data.cache_age_hours as number | null) ?? null,
 	}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,5 +1,26 @@
 /** Data schemas for wots CLI. */
 
+const VALID_RATE_LIMIT_TYPES = new Set(['transient', 'quota'])
+
+/** Validate rate-limit type is 'transient' | 'quota' | null. */
+function validRateLimitType(value: unknown): 'transient' | 'quota' | null {
+	return typeof value === 'string' && VALID_RATE_LIMIT_TYPES.has(value)
+		? (value as 'transient' | 'quota')
+		: null
+}
+
+/** Validate a non-negative finite number, or return null. */
+function safeNonNegNum(value: unknown): number | null {
+	if (typeof value !== 'number') return null
+	if (!Number.isFinite(value) || value < 0) return null
+	return value
+}
+
+/** Coerce to boolean, defaulting to false. */
+function safeBool(value: unknown): boolean {
+	return value === true
+}
+
 /** Engagement metrics. */
 export interface Engagement {
 	// Reddit fields
@@ -188,6 +209,19 @@ export function reportToDict(report: Report): Record<string, unknown> {
 	if (report.x_error) d.x_error = report.x_error
 	if (report.web_error) d.web_error = report.web_error
 	if (report.youtube_error) d.youtube_error = report.youtube_error
+	const hasRedditDiagnostics =
+		report.reddit_rate_limit_type != null ||
+		report.reddit_rate_limit_error_code != null ||
+		report.reddit_rate_limit_reset_ms != null ||
+		report.reddit_rate_limit_retry_after_ms != null ||
+		report.reddit_rate_limit_retries_attempted != null
+	const hasXDiagnostics =
+		report.x_rate_limit_type != null ||
+		report.x_rate_limit_error_code != null ||
+		report.x_rate_limit_reset_ms != null ||
+		report.x_rate_limit_retry_after_ms != null ||
+		report.x_rate_limit_retries_attempted != null
+
 	if (report.reddit_rate_limit_type)
 		d.reddit_rate_limit_type = report.reddit_rate_limit_type
 	if (report.reddit_rate_limit_error_code)
@@ -199,7 +233,7 @@ export function reportToDict(report: Report): Record<string, unknown> {
 	if (report.reddit_rate_limit_retries_attempted != null)
 		d.reddit_rate_limit_retries_attempted =
 			report.reddit_rate_limit_retries_attempted
-	if (report.reddit_used_stale_cache)
+	if (hasRedditDiagnostics || report.reddit_used_stale_cache)
 		d.reddit_used_stale_cache = report.reddit_used_stale_cache
 	if (report.reddit_used_stale_cache && report.reddit_cache_age_hours != null)
 		d.reddit_cache_age_hours = report.reddit_cache_age_hours
@@ -212,7 +246,7 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.x_rate_limit_retry_after_ms = report.x_rate_limit_retry_after_ms
 	if (report.x_rate_limit_retries_attempted != null)
 		d.x_rate_limit_retries_attempted = report.x_rate_limit_retries_attempted
-	if (report.x_used_stale_cache)
+	if (hasXDiagnostics || report.x_used_stale_cache)
 		d.x_used_stale_cache = report.x_used_stale_cache
 	if (report.x_used_stale_cache && report.x_cache_age_hours != null)
 		d.x_cache_age_hours = report.x_cache_age_hours
@@ -474,34 +508,31 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 		x_error: (data.x_error as string | null) ?? null,
 		web_error: (data.web_error as string | null) ?? null,
 		youtube_error: (data.youtube_error as string | null) ?? null,
-		reddit_rate_limit_type:
-			(data.reddit_rate_limit_type as 'transient' | 'quota' | null) ?? null,
+		reddit_rate_limit_type: validRateLimitType(data.reddit_rate_limit_type),
 		reddit_rate_limit_error_code:
 			(data.reddit_rate_limit_error_code as string | null) ?? null,
-		reddit_rate_limit_reset_ms:
-			(data.reddit_rate_limit_reset_ms as number | null) ?? null,
-		reddit_rate_limit_retry_after_ms:
-			(data.reddit_rate_limit_retry_after_ms as number | null) ?? null,
-		reddit_rate_limit_retries_attempted:
-			(data.reddit_rate_limit_retries_attempted as number | null) ?? null,
-		reddit_used_stale_cache:
-			(data.reddit_used_stale_cache as boolean | undefined) ?? false,
-		reddit_cache_age_hours:
-			(data.reddit_cache_age_hours as number | null) ?? null,
-		x_rate_limit_type:
-			(data.x_rate_limit_type as 'transient' | 'quota' | null) ?? null,
+		reddit_rate_limit_reset_ms: safeNonNegNum(data.reddit_rate_limit_reset_ms),
+		reddit_rate_limit_retry_after_ms: safeNonNegNum(
+			data.reddit_rate_limit_retry_after_ms,
+		),
+		reddit_rate_limit_retries_attempted: safeNonNegNum(
+			data.reddit_rate_limit_retries_attempted,
+		),
+		reddit_used_stale_cache: safeBool(data.reddit_used_stale_cache),
+		reddit_cache_age_hours: safeNonNegNum(data.reddit_cache_age_hours),
+		x_rate_limit_type: validRateLimitType(data.x_rate_limit_type),
 		x_rate_limit_error_code:
 			(data.x_rate_limit_error_code as string | null) ?? null,
-		x_rate_limit_reset_ms:
-			(data.x_rate_limit_reset_ms as number | null) ?? null,
-		x_rate_limit_retry_after_ms:
-			(data.x_rate_limit_retry_after_ms as number | null) ?? null,
-		x_rate_limit_retries_attempted:
-			(data.x_rate_limit_retries_attempted as number | null) ?? null,
-		x_used_stale_cache:
-			(data.x_used_stale_cache as boolean | undefined) ?? false,
-		x_cache_age_hours: (data.x_cache_age_hours as number | null) ?? null,
-		from_cache: (data.from_cache as boolean | undefined) ?? false,
-		cache_age_hours: (data.cache_age_hours as number | null) ?? null,
+		x_rate_limit_reset_ms: safeNonNegNum(data.x_rate_limit_reset_ms),
+		x_rate_limit_retry_after_ms: safeNonNegNum(
+			data.x_rate_limit_retry_after_ms,
+		),
+		x_rate_limit_retries_attempted: safeNonNegNum(
+			data.x_rate_limit_retries_attempted,
+		),
+		x_used_stale_cache: safeBool(data.x_used_stale_cache),
+		x_cache_age_hours: safeNonNegNum(data.x_cache_age_hours),
+		from_cache: safeBool(data.from_cache),
+		cache_age_hours: safeNonNegNum(data.cache_age_hours),
 	}
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -129,11 +129,13 @@ export interface Report {
 	reddit_rate_limit_error_code: string | null
 	reddit_rate_limit_reset_ms: number | null
 	reddit_rate_limit_retry_after_ms: number | null
+	reddit_rate_limit_retries_attempted: number | null
 	reddit_used_stale_cache: boolean
 	x_rate_limit_type: 'transient' | 'quota' | null
 	x_rate_limit_error_code: string | null
 	x_rate_limit_reset_ms: number | null
 	x_rate_limit_retry_after_ms: number | null
+	x_rate_limit_retries_attempted: number | null
 	x_used_stale_cache: boolean
 	from_cache: boolean
 	cache_age_hours: number | null
@@ -192,6 +194,9 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.reddit_rate_limit_reset_ms = report.reddit_rate_limit_reset_ms
 	if (report.reddit_rate_limit_retry_after_ms != null)
 		d.reddit_rate_limit_retry_after_ms = report.reddit_rate_limit_retry_after_ms
+	if (report.reddit_rate_limit_retries_attempted != null)
+		d.reddit_rate_limit_retries_attempted =
+			report.reddit_rate_limit_retries_attempted
 	if (report.reddit_used_stale_cache)
 		d.reddit_used_stale_cache = report.reddit_used_stale_cache
 	if (report.x_rate_limit_type) d.x_rate_limit_type = report.x_rate_limit_type
@@ -201,6 +206,8 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.x_rate_limit_reset_ms = report.x_rate_limit_reset_ms
 	if (report.x_rate_limit_retry_after_ms != null)
 		d.x_rate_limit_retry_after_ms = report.x_rate_limit_retry_after_ms
+	if (report.x_rate_limit_retries_attempted != null)
+		d.x_rate_limit_retries_attempted = report.x_rate_limit_retries_attempted
 	if (report.x_used_stale_cache)
 		d.x_used_stale_cache = report.x_used_stale_cache
 	if (report.from_cache) d.from_cache = report.from_cache
@@ -337,11 +344,13 @@ export function createReport(
 		reddit_rate_limit_error_code: null,
 		reddit_rate_limit_reset_ms: null,
 		reddit_rate_limit_retry_after_ms: null,
+		reddit_rate_limit_retries_attempted: null,
 		reddit_used_stale_cache: false,
 		x_rate_limit_type: null,
 		x_rate_limit_error_code: null,
 		x_rate_limit_reset_ms: null,
 		x_rate_limit_retry_after_ms: null,
+		x_rate_limit_retries_attempted: null,
 		x_used_stale_cache: false,
 		from_cache: false,
 		cache_age_hours: null,
@@ -465,7 +474,10 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.reddit_rate_limit_reset_ms as number | null) ?? null,
 		reddit_rate_limit_retry_after_ms:
 			(data.reddit_rate_limit_retry_after_ms as number | null) ?? null,
-		reddit_used_stale_cache: (data.reddit_used_stale_cache as boolean) ?? false,
+		reddit_rate_limit_retries_attempted:
+			(data.reddit_rate_limit_retries_attempted as number | null) ?? null,
+		reddit_used_stale_cache:
+			(data.reddit_used_stale_cache as boolean | undefined) ?? false,
 		x_rate_limit_type:
 			(data.x_rate_limit_type as 'transient' | 'quota' | null) ?? null,
 		x_rate_limit_error_code:
@@ -474,8 +486,11 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.x_rate_limit_reset_ms as number | null) ?? null,
 		x_rate_limit_retry_after_ms:
 			(data.x_rate_limit_retry_after_ms as number | null) ?? null,
-		x_used_stale_cache: (data.x_used_stale_cache as boolean) ?? false,
-		from_cache: (data.from_cache as boolean) ?? false,
+		x_rate_limit_retries_attempted:
+			(data.x_rate_limit_retries_attempted as number | null) ?? null,
+		x_used_stale_cache:
+			(data.x_used_stale_cache as boolean | undefined) ?? false,
+		from_cache: (data.from_cache as boolean | undefined) ?? false,
 		cache_age_hours: (data.cache_age_hours as number | null) ?? null,
 	}
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -128,10 +128,12 @@ export interface Report {
 	reddit_rate_limit_type: 'transient' | 'quota' | null
 	reddit_rate_limit_error_code: string | null
 	reddit_rate_limit_reset_ms: number | null
+	reddit_rate_limit_retry_after_ms: number | null
 	reddit_used_stale_cache: boolean
 	x_rate_limit_type: 'transient' | 'quota' | null
 	x_rate_limit_error_code: string | null
 	x_rate_limit_reset_ms: number | null
+	x_rate_limit_retry_after_ms: number | null
 	x_used_stale_cache: boolean
 	from_cache: boolean
 	cache_age_hours: number | null
@@ -188,6 +190,8 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.reddit_rate_limit_error_code = report.reddit_rate_limit_error_code
 	if (report.reddit_rate_limit_reset_ms != null)
 		d.reddit_rate_limit_reset_ms = report.reddit_rate_limit_reset_ms
+	if (report.reddit_rate_limit_retry_after_ms != null)
+		d.reddit_rate_limit_retry_after_ms = report.reddit_rate_limit_retry_after_ms
 	if (report.reddit_used_stale_cache)
 		d.reddit_used_stale_cache = report.reddit_used_stale_cache
 	if (report.x_rate_limit_type) d.x_rate_limit_type = report.x_rate_limit_type
@@ -195,6 +199,8 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.x_rate_limit_error_code = report.x_rate_limit_error_code
 	if (report.x_rate_limit_reset_ms != null)
 		d.x_rate_limit_reset_ms = report.x_rate_limit_reset_ms
+	if (report.x_rate_limit_retry_after_ms != null)
+		d.x_rate_limit_retry_after_ms = report.x_rate_limit_retry_after_ms
 	if (report.x_used_stale_cache)
 		d.x_used_stale_cache = report.x_used_stale_cache
 	if (report.from_cache) d.from_cache = report.from_cache
@@ -330,10 +336,12 @@ export function createReport(
 		reddit_rate_limit_type: null,
 		reddit_rate_limit_error_code: null,
 		reddit_rate_limit_reset_ms: null,
+		reddit_rate_limit_retry_after_ms: null,
 		reddit_used_stale_cache: false,
 		x_rate_limit_type: null,
 		x_rate_limit_error_code: null,
 		x_rate_limit_reset_ms: null,
+		x_rate_limit_retry_after_ms: null,
 		x_used_stale_cache: false,
 		from_cache: false,
 		cache_age_hours: null,
@@ -455,6 +463,8 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.reddit_rate_limit_error_code as string | null) ?? null,
 		reddit_rate_limit_reset_ms:
 			(data.reddit_rate_limit_reset_ms as number | null) ?? null,
+		reddit_rate_limit_retry_after_ms:
+			(data.reddit_rate_limit_retry_after_ms as number | null) ?? null,
 		reddit_used_stale_cache: (data.reddit_used_stale_cache as boolean) ?? false,
 		x_rate_limit_type:
 			(data.x_rate_limit_type as 'transient' | 'quota' | null) ?? null,
@@ -462,6 +472,8 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 			(data.x_rate_limit_error_code as string | null) ?? null,
 		x_rate_limit_reset_ms:
 			(data.x_rate_limit_reset_ms as number | null) ?? null,
+		x_rate_limit_retry_after_ms:
+			(data.x_rate_limit_retry_after_ms as number | null) ?? null,
 		x_used_stale_cache: (data.x_used_stale_cache as boolean) ?? false,
 		from_cache: (data.from_cache as boolean) ?? false,
 		cache_age_hours: (data.cache_age_hours as number | null) ?? null,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -201,7 +201,7 @@ export function reportToDict(report: Report): Record<string, unknown> {
 			report.reddit_rate_limit_retries_attempted
 	if (report.reddit_used_stale_cache)
 		d.reddit_used_stale_cache = report.reddit_used_stale_cache
-	if (report.reddit_cache_age_hours != null)
+	if (report.reddit_used_stale_cache && report.reddit_cache_age_hours != null)
 		d.reddit_cache_age_hours = report.reddit_cache_age_hours
 	if (report.x_rate_limit_type) d.x_rate_limit_type = report.x_rate_limit_type
 	if (report.x_rate_limit_error_code)
@@ -214,7 +214,7 @@ export function reportToDict(report: Report): Record<string, unknown> {
 		d.x_rate_limit_retries_attempted = report.x_rate_limit_retries_attempted
 	if (report.x_used_stale_cache)
 		d.x_used_stale_cache = report.x_used_stale_cache
-	if (report.x_cache_age_hours != null)
+	if (report.x_used_stale_cache && report.x_cache_age_hours != null)
 		d.x_cache_age_hours = report.x_cache_age_hours
 	if (report.from_cache) d.from_cache = report.from_cache
 	if (report.cache_age_hours != null) d.cache_age_hours = report.cache_age_hours

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -125,6 +125,14 @@ export interface Report {
 	x_error: string | null
 	web_error: string | null
 	youtube_error: string | null
+	reddit_rate_limit_type: 'transient' | 'quota' | null
+	reddit_rate_limit_error_code: string | null
+	reddit_rate_limit_reset_ms: number | null
+	reddit_used_stale_cache: boolean
+	x_rate_limit_type: 'transient' | 'quota' | null
+	x_rate_limit_error_code: string | null
+	x_rate_limit_reset_ms: number | null
+	x_used_stale_cache: boolean
 	from_cache: boolean
 	cache_age_hours: number | null
 }
@@ -174,6 +182,21 @@ export function reportToDict(report: Report): Record<string, unknown> {
 	if (report.x_error) d.x_error = report.x_error
 	if (report.web_error) d.web_error = report.web_error
 	if (report.youtube_error) d.youtube_error = report.youtube_error
+	if (report.reddit_rate_limit_type)
+		d.reddit_rate_limit_type = report.reddit_rate_limit_type
+	if (report.reddit_rate_limit_error_code)
+		d.reddit_rate_limit_error_code = report.reddit_rate_limit_error_code
+	if (report.reddit_rate_limit_reset_ms != null)
+		d.reddit_rate_limit_reset_ms = report.reddit_rate_limit_reset_ms
+	if (report.reddit_used_stale_cache)
+		d.reddit_used_stale_cache = report.reddit_used_stale_cache
+	if (report.x_rate_limit_type) d.x_rate_limit_type = report.x_rate_limit_type
+	if (report.x_rate_limit_error_code)
+		d.x_rate_limit_error_code = report.x_rate_limit_error_code
+	if (report.x_rate_limit_reset_ms != null)
+		d.x_rate_limit_reset_ms = report.x_rate_limit_reset_ms
+	if (report.x_used_stale_cache)
+		d.x_used_stale_cache = report.x_used_stale_cache
 	if (report.from_cache) d.from_cache = report.from_cache
 	if (report.cache_age_hours != null) d.cache_age_hours = report.cache_age_hours
 	return d
@@ -304,6 +327,14 @@ export function createReport(
 		x_error: null,
 		web_error: null,
 		youtube_error: null,
+		reddit_rate_limit_type: null,
+		reddit_rate_limit_error_code: null,
+		reddit_rate_limit_reset_ms: null,
+		reddit_used_stale_cache: false,
+		x_rate_limit_type: null,
+		x_rate_limit_error_code: null,
+		x_rate_limit_reset_ms: null,
+		x_used_stale_cache: false,
 		from_cache: false,
 		cache_age_hours: null,
 	}
@@ -418,6 +449,20 @@ export function reportFromDict(data: Record<string, unknown>): Report {
 		x_error: (data.x_error as string | null) ?? null,
 		web_error: (data.web_error as string | null) ?? null,
 		youtube_error: (data.youtube_error as string | null) ?? null,
+		reddit_rate_limit_type:
+			(data.reddit_rate_limit_type as 'transient' | 'quota' | null) ?? null,
+		reddit_rate_limit_error_code:
+			(data.reddit_rate_limit_error_code as string | null) ?? null,
+		reddit_rate_limit_reset_ms:
+			(data.reddit_rate_limit_reset_ms as number | null) ?? null,
+		reddit_used_stale_cache: (data.reddit_used_stale_cache as boolean) ?? false,
+		x_rate_limit_type:
+			(data.x_rate_limit_type as 'transient' | 'quota' | null) ?? null,
+		x_rate_limit_error_code:
+			(data.x_rate_limit_error_code as string | null) ?? null,
+		x_rate_limit_reset_ms:
+			(data.x_rate_limit_reset_ms as number | null) ?? null,
+		x_used_stale_cache: (data.x_used_stale_cache as boolean) ?? false,
 		from_cache: (data.from_cache as boolean) ?? false,
 		cache_age_hours: (data.cache_age_hours as number | null) ?? null,
 	}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -260,6 +260,7 @@ describe('schema', () => {
 		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
 		report.reddit_rate_limit_reset_ms = 45000
 		report.reddit_rate_limit_retry_after_ms = 3000
+		report.reddit_rate_limit_retries_attempted = 5
 		report.reddit_used_stale_cache = true
 		// x fields left at defaults (null/false)
 		const dict = reportToDict(report)
@@ -267,12 +268,14 @@ describe('schema', () => {
 		expect(dict.reddit_rate_limit_error_code).toBe('rate_limit_exceeded')
 		expect(dict.reddit_rate_limit_reset_ms).toBe(45000)
 		expect(dict.reddit_rate_limit_retry_after_ms).toBe(3000)
+		expect(dict.reddit_rate_limit_retries_attempted).toBe(5)
 		expect(dict.reddit_used_stale_cache).toBe(true)
 		// x fields should be absent (conditional inclusion)
 		expect(dict.x_rate_limit_type).toBeUndefined()
 		expect(dict.x_rate_limit_error_code).toBeUndefined()
 		expect(dict.x_rate_limit_reset_ms).toBeUndefined()
 		expect(dict.x_rate_limit_retry_after_ms).toBeUndefined()
+		expect(dict.x_rate_limit_retries_attempted).toBeUndefined()
 		expect(dict.x_used_stale_cache).toBeUndefined()
 	})
 
@@ -290,11 +293,13 @@ describe('schema', () => {
 		expect(report.reddit_rate_limit_error_code).toBeNull()
 		expect(report.reddit_rate_limit_reset_ms).toBeNull()
 		expect(report.reddit_rate_limit_retry_after_ms).toBeNull()
+		expect(report.reddit_rate_limit_retries_attempted).toBeNull()
 		expect(report.reddit_used_stale_cache).toBe(false)
 		expect(report.x_rate_limit_type).toBeNull()
 		expect(report.x_rate_limit_error_code).toBeNull()
 		expect(report.x_rate_limit_reset_ms).toBeNull()
 		expect(report.x_rate_limit_retry_after_ms).toBeNull()
+		expect(report.x_rate_limit_retries_attempted).toBeNull()
 		expect(report.x_used_stale_cache).toBe(false)
 	})
 })
@@ -364,12 +369,13 @@ describe('render', () => {
 		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
 		report.reddit_rate_limit_reset_ms = 45000
 		report.reddit_rate_limit_retry_after_ms = 3000
+		report.reddit_rate_limit_retries_attempted = 5
 		const output = renderCompact(report)
-		expect(output).toContain('**reddit_status:** rate_limited')
 		expect(output).toContain('**reddit_rate_limit_type:** transient')
-		expect(output).toContain('**reddit_error_code:** rate_limit_exceeded')
+		expect(output).toContain('**reddit_rate_limit_error_code:** rate_limit_exceeded')
 		expect(output).toContain('**reddit_rate_limit_reset:** 45s')
-		expect(output).toContain('**reddit_retry_after:** 3s')
+		expect(output).toContain('**reddit_rate_limit_retry_after:** 3s')
+		expect(output).toContain('**reddit_rate_limit_retries_attempted:** 5')
 		expect(output).not.toContain('**ERROR:**')
 	})
 
@@ -380,7 +386,6 @@ describe('render', () => {
 		report.x_used_stale_cache = true
 		report.cache_age_hours = 2.5
 		const output = renderCompact(report)
-		expect(output).toContain('**x_status:** rate_limited')
 		expect(output).toContain('**x_fallback:** stale_cache (age: 2.5h)')
 	})
 
@@ -390,6 +395,15 @@ describe('render', () => {
 		const output = renderCompact(report)
 		expect(output).toContain('**ERROR:** API error: connection timeout')
 		expect(output).not.toContain('rate_limited')
+	})
+
+	test('renderCompact sanitizes rate-limit error code control chars', () => {
+		const report = createReport('testing', '2025-01-01', '2025-01-31', 'both')
+		report.reddit_error = 'Rate limited after 1 retries'
+		report.reddit_rate_limit_type = 'transient'
+		report.reddit_rate_limit_error_code = 'bad\ncode\tvalue'
+		const output = renderCompact(report)
+		expect(output).toContain('**reddit_rate_limit_error_code:** bad code value')
 	})
 })
 
@@ -1206,11 +1220,13 @@ describe('cli', () => {
 		expect(output.reddit_rate_limit_error_code).toBeUndefined()
 		expect(output.reddit_rate_limit_reset_ms).toBeUndefined()
 		expect(output.reddit_rate_limit_retry_after_ms).toBeUndefined()
+		expect(output.reddit_rate_limit_retries_attempted).toBeUndefined()
 		expect(output.reddit_used_stale_cache).toBeUndefined()
 		expect(output.x_rate_limit_type).toBeUndefined()
 		expect(output.x_rate_limit_error_code).toBeUndefined()
 		expect(output.x_rate_limit_reset_ms).toBeUndefined()
 		expect(output.x_rate_limit_retry_after_ms).toBeUndefined()
+		expect(output.x_rate_limit_retries_attempted).toBeUndefined()
 		expect(output.x_used_stale_cache).toBeUndefined()
 	})
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -262,6 +262,7 @@ describe('schema', () => {
 		report.reddit_rate_limit_retry_after_ms = 3000
 		report.reddit_rate_limit_retries_attempted = 5
 		report.reddit_used_stale_cache = true
+		report.reddit_cache_age_hours = 1.25
 		// x fields left at defaults (null/false)
 		const dict = reportToDict(report)
 		expect(dict.reddit_rate_limit_type).toBe('transient')
@@ -270,6 +271,7 @@ describe('schema', () => {
 		expect(dict.reddit_rate_limit_retry_after_ms).toBe(3000)
 		expect(dict.reddit_rate_limit_retries_attempted).toBe(5)
 		expect(dict.reddit_used_stale_cache).toBe(true)
+		expect(dict.reddit_cache_age_hours).toBe(1.25)
 		// x fields should be absent (conditional inclusion)
 		expect(dict.x_rate_limit_type).toBeUndefined()
 		expect(dict.x_rate_limit_error_code).toBeUndefined()
@@ -277,6 +279,7 @@ describe('schema', () => {
 		expect(dict.x_rate_limit_retry_after_ms).toBeUndefined()
 		expect(dict.x_rate_limit_retries_attempted).toBeUndefined()
 		expect(dict.x_used_stale_cache).toBeUndefined()
+		expect(dict.x_cache_age_hours).toBeUndefined()
 	})
 
 	test('reportFromDict defaults missing rate-limit fields for backward compat', () => {
@@ -295,12 +298,14 @@ describe('schema', () => {
 		expect(report.reddit_rate_limit_retry_after_ms).toBeNull()
 		expect(report.reddit_rate_limit_retries_attempted).toBeNull()
 		expect(report.reddit_used_stale_cache).toBe(false)
+		expect(report.reddit_cache_age_hours).toBeNull()
 		expect(report.x_rate_limit_type).toBeNull()
 		expect(report.x_rate_limit_error_code).toBeNull()
 		expect(report.x_rate_limit_reset_ms).toBeNull()
 		expect(report.x_rate_limit_retry_after_ms).toBeNull()
 		expect(report.x_rate_limit_retries_attempted).toBeNull()
 		expect(report.x_used_stale_cache).toBe(false)
+		expect(report.x_cache_age_hours).toBeNull()
 	})
 })
 
@@ -384,9 +389,21 @@ describe('render', () => {
 		report.x_error = 'Rate limited after 3 retries'
 		report.x_rate_limit_type = 'transient'
 		report.x_used_stale_cache = true
-		report.cache_age_hours = 2.5
+		report.x_cache_age_hours = 2.5
 		const output = renderCompact(report)
 		expect(output).toContain('**x_fallback:** stale_cache (age: 2.5h)')
+	})
+
+	test('renderCompact uses source-specific cache age and shows 0.0h', () => {
+		const report = createReport('testing', '2025-01-01', '2025-01-31', 'both')
+		report.reddit_error = 'Rate limited after 2 retries'
+		report.reddit_rate_limit_type = 'transient'
+		report.reddit_used_stale_cache = true
+		report.reddit_cache_age_hours = 0
+		report.cache_age_hours = 9.9
+		const output = renderCompact(report)
+		expect(output).toContain('**reddit_fallback:** stale_cache (age: 0.0h)')
+		expect(output).not.toContain('age: 9.9h')
 	})
 
 	test('renderCompact preserves plain ERROR for non-rate-limit errors', () => {
@@ -1222,12 +1239,14 @@ describe('cli', () => {
 		expect(output.reddit_rate_limit_retry_after_ms).toBeUndefined()
 		expect(output.reddit_rate_limit_retries_attempted).toBeUndefined()
 		expect(output.reddit_used_stale_cache).toBeUndefined()
+		expect(output.reddit_cache_age_hours).toBeUndefined()
 		expect(output.x_rate_limit_type).toBeUndefined()
 		expect(output.x_rate_limit_error_code).toBeUndefined()
 		expect(output.x_rate_limit_reset_ms).toBeUndefined()
 		expect(output.x_rate_limit_retry_after_ms).toBeUndefined()
 		expect(output.x_rate_limit_retries_attempted).toBeUndefined()
 		expect(output.x_used_stale_cache).toBeUndefined()
+		expect(output.x_cache_age_hours).toBeUndefined()
 	})
 
 	test('--quick + --deep exits with EXIT_CONFLICT', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -259,17 +259,20 @@ describe('schema', () => {
 		report.reddit_rate_limit_type = 'transient'
 		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
 		report.reddit_rate_limit_reset_ms = 45000
+		report.reddit_rate_limit_retry_after_ms = 3000
 		report.reddit_used_stale_cache = true
 		// x fields left at defaults (null/false)
 		const dict = reportToDict(report)
 		expect(dict.reddit_rate_limit_type).toBe('transient')
 		expect(dict.reddit_rate_limit_error_code).toBe('rate_limit_exceeded')
 		expect(dict.reddit_rate_limit_reset_ms).toBe(45000)
+		expect(dict.reddit_rate_limit_retry_after_ms).toBe(3000)
 		expect(dict.reddit_used_stale_cache).toBe(true)
 		// x fields should be absent (conditional inclusion)
 		expect(dict.x_rate_limit_type).toBeUndefined()
 		expect(dict.x_rate_limit_error_code).toBeUndefined()
 		expect(dict.x_rate_limit_reset_ms).toBeUndefined()
+		expect(dict.x_rate_limit_retry_after_ms).toBeUndefined()
 		expect(dict.x_used_stale_cache).toBeUndefined()
 	})
 
@@ -286,10 +289,12 @@ describe('schema', () => {
 		expect(report.reddit_rate_limit_type).toBeNull()
 		expect(report.reddit_rate_limit_error_code).toBeNull()
 		expect(report.reddit_rate_limit_reset_ms).toBeNull()
+		expect(report.reddit_rate_limit_retry_after_ms).toBeNull()
 		expect(report.reddit_used_stale_cache).toBe(false)
 		expect(report.x_rate_limit_type).toBeNull()
 		expect(report.x_rate_limit_error_code).toBeNull()
 		expect(report.x_rate_limit_reset_ms).toBeNull()
+		expect(report.x_rate_limit_retry_after_ms).toBeNull()
 		expect(report.x_used_stale_cache).toBe(false)
 	})
 })
@@ -358,11 +363,13 @@ describe('render', () => {
 		report.reddit_rate_limit_type = 'transient'
 		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
 		report.reddit_rate_limit_reset_ms = 45000
+		report.reddit_rate_limit_retry_after_ms = 3000
 		const output = renderCompact(report)
 		expect(output).toContain('**reddit_status:** rate_limited')
 		expect(output).toContain('**reddit_rate_limit_type:** transient')
 		expect(output).toContain('**reddit_error_code:** rate_limit_exceeded')
 		expect(output).toContain('**reddit_rate_limit_reset:** 45s')
+		expect(output).toContain('**reddit_retry_after:** 3s')
 		expect(output).not.toContain('**ERROR:**')
 	})
 
@@ -1198,10 +1205,12 @@ describe('cli', () => {
 		expect(output.reddit_rate_limit_type).toBeUndefined()
 		expect(output.reddit_rate_limit_error_code).toBeUndefined()
 		expect(output.reddit_rate_limit_reset_ms).toBeUndefined()
+		expect(output.reddit_rate_limit_retry_after_ms).toBeUndefined()
 		expect(output.reddit_used_stale_cache).toBeUndefined()
 		expect(output.x_rate_limit_type).toBeUndefined()
 		expect(output.x_rate_limit_error_code).toBeUndefined()
 		expect(output.x_rate_limit_reset_ms).toBeUndefined()
+		expect(output.x_rate_limit_retry_after_ms).toBeUndefined()
 		expect(output.x_used_stale_cache).toBeUndefined()
 	})
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -253,6 +253,45 @@ describe('schema', () => {
 		})
 		expect(report.days).toBe(14)
 	})
+
+	test('reportToDict includes rate-limit fields when set, omits when null', () => {
+		const report = createReport('test', '2025-01-01', '2025-01-31', 'both')
+		report.reddit_rate_limit_type = 'transient'
+		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
+		report.reddit_rate_limit_reset_ms = 45000
+		report.reddit_used_stale_cache = true
+		// x fields left at defaults (null/false)
+		const dict = reportToDict(report)
+		expect(dict.reddit_rate_limit_type).toBe('transient')
+		expect(dict.reddit_rate_limit_error_code).toBe('rate_limit_exceeded')
+		expect(dict.reddit_rate_limit_reset_ms).toBe(45000)
+		expect(dict.reddit_used_stale_cache).toBe(true)
+		// x fields should be absent (conditional inclusion)
+		expect(dict.x_rate_limit_type).toBeUndefined()
+		expect(dict.x_rate_limit_error_code).toBeUndefined()
+		expect(dict.x_rate_limit_reset_ms).toBeUndefined()
+		expect(dict.x_used_stale_cache).toBeUndefined()
+	})
+
+	test('reportFromDict defaults missing rate-limit fields for backward compat', () => {
+		const report = reportFromDict({
+			topic: 'old-report',
+			range: { from: '2025-01-01', to: '2025-01-31' },
+			generated_at: '2025-01-31T00:00:00.000Z',
+			mode: 'both',
+			reddit: [],
+			x: [],
+			web: [],
+		})
+		expect(report.reddit_rate_limit_type).toBeNull()
+		expect(report.reddit_rate_limit_error_code).toBeNull()
+		expect(report.reddit_rate_limit_reset_ms).toBeNull()
+		expect(report.reddit_used_stale_cache).toBe(false)
+		expect(report.x_rate_limit_type).toBeNull()
+		expect(report.x_rate_limit_error_code).toBeNull()
+		expect(report.x_rate_limit_reset_ms).toBeNull()
+		expect(report.x_used_stale_cache).toBe(false)
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -311,6 +350,39 @@ describe('render', () => {
 	test('getContextPath uses outdir when provided', () => {
 		const path = getContextPath('/tmp/custom-outdir')
 		expect(path).toBe('/tmp/custom-outdir/wots.context.md')
+	})
+
+	test('renderCompact shows structured rate-limit diagnostics', () => {
+		const report = createReport('testing', '2025-01-01', '2025-01-31', 'both')
+		report.reddit_error = 'Rate limited after 5 retries'
+		report.reddit_rate_limit_type = 'transient'
+		report.reddit_rate_limit_error_code = 'rate_limit_exceeded'
+		report.reddit_rate_limit_reset_ms = 45000
+		const output = renderCompact(report)
+		expect(output).toContain('**reddit_status:** rate_limited')
+		expect(output).toContain('**reddit_rate_limit_type:** transient')
+		expect(output).toContain('**reddit_error_code:** rate_limit_exceeded')
+		expect(output).toContain('**reddit_rate_limit_reset:** 45s')
+		expect(output).not.toContain('**ERROR:**')
+	})
+
+	test('renderCompact shows stale cache fallback info', () => {
+		const report = createReport('testing', '2025-01-01', '2025-01-31', 'both')
+		report.x_error = 'Rate limited after 3 retries'
+		report.x_rate_limit_type = 'transient'
+		report.x_used_stale_cache = true
+		report.cache_age_hours = 2.5
+		const output = renderCompact(report)
+		expect(output).toContain('**x_status:** rate_limited')
+		expect(output).toContain('**x_fallback:** stale_cache (age: 2.5h)')
+	})
+
+	test('renderCompact preserves plain ERROR for non-rate-limit errors', () => {
+		const report = createReport('testing', '2025-01-01', '2025-01-31', 'both')
+		report.reddit_error = 'API error: connection timeout'
+		const output = renderCompact(report)
+		expect(output).toContain('**ERROR:** API error: connection timeout')
+		expect(output).not.toContain('rate_limited')
 	})
 })
 
@@ -1117,6 +1189,20 @@ describe('cli', () => {
 		expect(result.exitCode).toBe(0)
 		const output = JSON.parse(new TextDecoder().decode(result.stdout)) as Record<string, unknown>
 		expect(output.youtube).toBeUndefined()
+	})
+
+	test('no rate-limit fields in mock JSON output (happy path)', () => {
+		const result = runCli(['test topic', '--mock', '--emit=json'])
+		expect(result.exitCode).toBe(0)
+		const output = JSON.parse(new TextDecoder().decode(result.stdout)) as Record<string, unknown>
+		expect(output.reddit_rate_limit_type).toBeUndefined()
+		expect(output.reddit_rate_limit_error_code).toBeUndefined()
+		expect(output.reddit_rate_limit_reset_ms).toBeUndefined()
+		expect(output.reddit_used_stale_cache).toBeUndefined()
+		expect(output.x_rate_limit_type).toBeUndefined()
+		expect(output.x_rate_limit_error_code).toBeUndefined()
+		expect(output.x_rate_limit_reset_ms).toBeUndefined()
+		expect(output.x_used_stale_cache).toBeUndefined()
 	})
 
 	test('--quick + --deep exits with EXIT_CONFLICT', () => {


### PR DESCRIPTION
## Summary

Closes #63

When rate limits hit, `RateLimitError` in `http.ts` carries rich fields (`error_code`, `retryable`, `ratelimit_reset_ms`, `retries_attempted`) but catch blocks in `cli.ts` were discarding all of it into flat strings like "Rate limited after 5 retries". Agents and CI consumers couldn't distinguish transient throttling from billing failures.

- Extend `SearchTaskResult` with 5 rate-limit fields per source (`rateLimitType`, `rateLimitErrorCode`, `rateLimitResetMs`, `rateLimitRetryAfterMs`, `rateLimitRetries`)
- Add 12 flat fields to `Report` schema per source: `{source}_rate_limit_type`, `_error_code`, `_reset_ms`, `_retry_after_ms`, `_retries_attempted`, `_used_stale_cache`, `_cache_age_hours`
- Wire task results into report assembly via a `taskResults` container object (avoids TS `never` narrowing in `.then()` callbacks)
- `renderCompact` now renders structured diagnostics block for rate-limit errors instead of plain `**ERROR:**`
- `retry_after_ms` captured separately from `reset_ms` to cover xAI's `Retry-After` header (xAI doesn't document `x-ratelimit-reset-*`)
- Conditional inclusion in `reportToDict` - fields omitted from JSON on happy path (clean output)
- Remove unused `summarizeFreshness` function

## Structured diagnostic output

Before:
```
### Reddit Threads

**ERROR:** Rate limited after 5 retries
```

After (rate-limit):
```
### Reddit Threads

**reddit_rate_limit_type:** transient
**reddit_rate_limit_error_code:** rate_limit_exceeded
**reddit_rate_limit_reset:** 45s
**reddit_rate_limit_retry_after:** 3s
**reddit_rate_limit_retries_attempted:** 5
**reddit_fallback:** stale_cache (age: 2.5h)
```

Non-rate-limit errors still render as `**ERROR:** <message>` unchanged.

## Testing

- 584 tests passing (up from 577)
- 7 new unit tests covering: `reportToDict` conditional inclusion, `reportFromDict` backward compat, `renderCompact` structured block, stale cache fallback, plain error preservation, sanitization, per-source cache age
- `--mock` JSON output absence test confirms no rate-limit fields on happy path

## Post-Deploy Monitoring & Validation

No runtime behaviour changes on the happy path - rate-limit fields are only populated when a 429 is encountered. The `reportToDict` conditional inclusion means existing JSON consumers see no new fields unless a rate limit actually occurred.

- **Validation:** Run `wots "test" --mock --emit=json` and confirm no `*_rate_limit_*` keys in output
- **Failure signal:** Any `*_rate_limit_*` key present in mock output would indicate a regression in conditional inclusion logic

No additional operational monitoring required beyond the above.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured rate‑limit diagnostics for Reddit and X are included in search results and final reports, plus per‑source stale‑cache indicators and cache ages; diagnostics render inline when present.
* **Refactor**
  * Compact output rendering now uses formatted rate‑limit blocks; previous freshness-summary logic removed.
* **Tests**
  * Added tests for rate‑limit serialization, diagnostics rendering, stale‑cache fallbacks, and CLI/report outputs.
* **Documentation**
  * Added observability/logging design and research specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->